### PR TITLE
refactor: remove `ready` state and `*-ready` event

### DIFF
--- a/components/combobox/demo/api.md
+++ b/components/combobox/demo/api.md
@@ -30,7 +30,6 @@
 
 | Event                       | Type               | Description                                      |
 |-----------------------------|--------------------|--------------------------------------------------|
-| `auroCombobox-ready`        | `CustomEvent<any>` | Notifies that the component has finished initializing. |
 | `auroCombobox-valueSet`     | `CustomEvent<any>` | Notifies that the component has a new value set. |
 | `auroFormElement-validated` |                    | Notifies that the component value(s) have been validated. |
 

--- a/components/combobox/demo/api.min.js
+++ b/components/combobox/demo/api.min.js
@@ -3064,7 +3064,6 @@ if (!customElements.get("auro-dropdownbib")) {
  * @csspart helpText - The helpText content container.
  * @csspart popover - The bib content container.
  * @event auroDropdown-triggerClick - Notifies that the trigger has been clicked.
- * @event auroDropdown-ready - Notifies that the component has finished initializing.
  * @event auroDropdown-toggled - Notifies that the visibility of the dropdown bib has changed.
  */
 class AuroDropdown extends r$5 {
@@ -3090,7 +3089,6 @@ class AuroDropdown extends r$5 {
     this.inset = false;
     this.placement = 'bottom-start';
     this.rounded = false;
-    this.ready = false;
     this.tabIndex = 0;
     this.noToggle = false;
 
@@ -3189,7 +3187,6 @@ class AuroDropdown extends r$5 {
         reflect: true
       },
       isPopoverVisible: { type: Boolean },
-      ready:            { type: Boolean },
       onSlotChange: {
         type: Function,
         reflect: false
@@ -3259,22 +3256,9 @@ class AuroDropdown extends r$5 {
     // Add the tag name as an attribute if it is different than the component name
     this.runtimeUtils.handleComponentTagRename(this, 'auro-dropdown');
 
-    this.notifyReady();
-  }
+    this.bibContent = this.shadowRoot.querySelector('auro-dropdownbib');
 
-  /**
-   * Marks the component as ready and sends event.
-   * @private
-   * @returns {void}
-   */
-  notifyReady() {
-    this.ready = true;
-
-    this.dispatchEvent(new CustomEvent('auroDropdown-ready', {
-      bubbles: true,
-      cancelable: false,
-      composed: true,
-    }));
+    document.body.append(this.bibContent);
   }
 
   /**
@@ -3356,7 +3340,7 @@ class AuroDropdown extends r$5 {
             <div class="triggerContent">
               <slot
                 name="trigger"
-                @slotchange="${() => {if (this.ready) this.floater.handleTriggerTabIndex(); }}"></slot>
+                @slotchange="${() => {this.floater.handleTriggerTabIndex(); }}"></slot>
             </div>
           </div>
           ${this.chevron || this.common ? u$1$1`
@@ -5463,7 +5447,6 @@ class AuroFormValidation {
  * @attr {String}  name - Populates the `name` attribute on the input.
  * @attr {Boolean} noValidate - If set, disables auto-validation on blur.
  * @attr {Boolean} readonly - Makes the input read-only, but can be set programmatically.
- * @prop {Boolean} ready - When false the component API should not be called.
  * @attr {Boolean} required - Populates the `required` attribute on the input. Used for client-side validation.
  * @attr {String}  pattern - Specifies a regular expression the form control's value should match.
  * @attr {String}  placeholder - Define custom placeholder text, only supported by date input formats.
@@ -5510,7 +5493,6 @@ class BaseInput extends r {
     this.maxLength = undefined;
     this.minLength = undefined;
     this.label = 'Input label is undefined';
-    this.ready = false;
     this.activeLabel = false;
 
     this.setCustomValidityForType = undefined;
@@ -5617,7 +5599,6 @@ class BaseInput extends r {
       showPassword:            { state: true },
       validateOnInput:         { type: Boolean },
       readonly:                { type: Boolean },
-      ready:                   { type: Boolean },
       error:                   {
         type: String,
         reflect: true
@@ -5856,8 +5837,6 @@ class BaseInput extends r {
         }
       }
     });
-
-    this.notifyReady();
   }
 
   /**
@@ -5956,20 +5935,6 @@ class BaseInput extends r {
    */
   notifyValidityChange() {
     this.dispatchEvent(new CustomEvent('auroInput-validityChange', {
-      bubbles: true,
-      cancelable: false,
-      composed: true,
-    }));
-  }
-
-  /**
-   * @private
-   * @returns {void} Marks the component as ready and sends event.
-   */
-  notifyReady() {
-    this.ready = true;
-
-    this.dispatchEvent(new CustomEvent('auroInput-ready', {
       bubbles: true,
       cancelable: false,
       composed: true,
@@ -7488,7 +7453,6 @@ var styleCss$3 = i$c`.util_displayInline{display:inline}.util_displayInlineBlock
  * @slot - Default slot for the menu content.
  * @slot label - Defines the content of the label.
  * @slot helpText - Defines the content of the helpText.
- * @event auroCombobox-ready - Notifies that the component has finished initializing.
  * @event auroCombobox-valueSet - Notifies that the component has a new value set.
  * @event auroFormElement-validated - Notifies that the component value(s) have been validated.
  */
@@ -7742,9 +7706,6 @@ class AuroCombobox extends r$6 {
     this.menuWrapper.append(this.menu);
 
     this.dropdown.setAttribute('role', 'combobox');
-    this.dropdown.addEventListener('auroDropdown-ready', () => {
-      this.auroDropdownReady = true;
-    });
 
     this.dropdown.addEventListener('auroDropdown-triggerClick', () => {
       this.showBib();
@@ -7780,15 +7741,6 @@ class AuroCombobox extends r$6 {
     } else {
       this.menu.setAttribute('nocheckmark', '');
     }
-
-    if (this.noFilter) {
-      this.auroMenuReady = true;
-    } else {
-      this.menu.addEventListener('auroMenu-ready', () => {
-        this.auroMenuReady = true;
-      });
-    }
-
 
     // handle the menu event for an option selection
     this.menu.addEventListener('auroMenu-selectedOption', () => {
@@ -7850,10 +7802,6 @@ class AuroCombobox extends r$6 {
    * @returns {void}
    */
   configureInput() {
-    this.input.addEventListener('auroInput-ready', () => {
-      this.auroInputReady = true;
-    });
-
     this.input.addEventListener('keyup', (evt) => {
       if (evt.key.length === 1 || evt.key === 'Backspace' || evt.key === 'Delete') {
         this.showBib();
@@ -7877,21 +7825,19 @@ class AuroCombobox extends r$6 {
       this.menu.matchWord = this.input.value;
       this.optionActive = null;
 
-      if (this.ready) {
-        if (this.value !== this.input.value) {
-          this.value = this.input.value;
-        }
-
-        if (this.value !== this.menu.value) {
-          this.menu.value = this.value;
-        }
-
-        if (this.optionSelected && this.input.value !== this.optionSelected.innerText) {
-          this.optionSelected = undefined;
-        }
-
-        this.menu.resetOptionsStates();
+      if (this.value !== this.input.value) {
+        this.value = this.input.value;
       }
+
+      if (this.value !== this.menu.value) {
+        this.menu.value = this.value;
+      }
+
+      if (this.optionSelected && this.input.value !== this.optionSelected.innerText) {
+        this.optionSelected = undefined;
+      }
+
+      this.menu.resetOptionsStates();
 
       this.handleMenuOptions();
 
@@ -8026,57 +7972,6 @@ class AuroCombobox extends r$6 {
     this.configureDropdown();
     this.configureCombobox();
 
-    this.checkReadiness();
-  }
-
-  /**
-   * @private
-   * @returns {void} Marks the component as ready and sends event.
-   */
-  notifyReady() {
-    this.ready = true;
-
-    this.dispatchEvent(new CustomEvent('auroCombobox-ready', {
-      bubbles: true,
-      cancelable: false,
-      composed: true,
-    }));
-  }
-
-  /**
-   * Monitors readiness of peer dependencies and begins work that should only start when ready.
-   * @private
-   * @returns {void}
-   */
-  checkReadiness() {
-    if (this.auroDropdownReady && this.auroInputReady && this.auroMenuReady) {
-      this.readyActions();
-      this.notifyReady();
-    } else {
-      // Start a retry counter to limit the retry count
-      if (!this.readyRetryCount && this.readyRetryCount !== 0) {
-        this.readyRetryCount = 0;
-      } else {
-        this.readyRetryCount += 1;
-      }
-
-      const readyTimer = 0;
-      const readyRetryLimit = 200;
-
-      if (this.readyRetryCount <= readyRetryLimit) {
-        setTimeout(() => {
-          this.checkReadiness();
-        }, readyTimer);
-      }
-    }
-  }
-
-  /**
-   * Functionality that should not be performed until the combobox is in a ready state.
-   * @private
-   * @returns {void}
-   */
-  readyActions() {
     // Set the initial value in auro-menu if defined
     if (this.hasAttribute('value') && this.getAttribute('value').length > 0) {
       this.menu.value = this.value;
@@ -8093,7 +7988,7 @@ class AuroCombobox extends r$6 {
 
   updated(changedProperties) {
     // After the component is ready, send direct value changes to auro-menu.
-    if (this.ready && changedProperties.has('value')) {
+    if (changedProperties.has('value')) {
       if (this.value) {
         if (this.optionSelected && this.optionSelected.value === this.value) {
           // If value updates and the previously selected option already matches the new value
@@ -8131,16 +8026,14 @@ class AuroCombobox extends r$6 {
    * @returns {void}
    */
   handleSlotChange() {
-    if (this.auroMenuReady) {
-      this.options = this.menu.querySelectorAll('auro-menuoption, [auro-menuoption]');
-      this.options.forEach((opt) => {
-        if (this.checkmark) {
-          opt.removeAttribute('nocheckmark');
-        } else {
-          opt.setAttribute('nocheckmark', '');
-        }
-      });
-    }
+    this.options = this.menu.querySelectorAll('auro-menuoption, [auro-menuoption]');
+    this.options.forEach((opt) => {
+      if (this.checkmark) {
+        opt.removeAttribute('nocheckmark');
+      } else {
+        opt.setAttribute('nocheckmark', '');
+      }
+    });
 
     this.handleMenuOptions();
   }
@@ -8721,7 +8614,6 @@ class AuroMenuOption extends r$6 {
  * @attr {Boolean} disabled - When true, the entire menu and all options are disabled;
  * @attr {Boolean} noCheckmark - When true, selected option will not show the checkmark.
  * @attr {String} value - Value selected for the menu.
- * @prop {Boolean} ready - When false the component API should not be called.
  * @event auroMenu-selectedOption - Notifies that a new menuoption selection has been made.
  * @event selectedOption - (DEPRECATED) Notifies that a new menuoption selection has been made.
  * @event auroMenu-activatedOption - Notifies that a menuoption has been made `active`.
@@ -8730,7 +8622,6 @@ class AuroMenuOption extends r$6 {
  * @event auroMenuSelectValueFailure - (DEPRECATED) Notifies that a an attempt to select a menuoption by matching a value has failed.
  * @event auroMenu-customEventFired - Notifies that a custom event has been fired.
  * @event auroMenuCustomEventFired - (DEPRECATED) Notifies that a custom event has been fired.
- * @event auroMenu-ready - Notifies that the component has finished initializing.
  * @event auroMenu-selectValueReset - Notifies that the component value has been reset.
  * @slot Slot for insertion of menu options.
  */
@@ -8744,7 +8635,6 @@ class AuroMenu extends r$6 {
     this.optionSelected = undefined;
     this.matchWord = undefined;
     this.noCheckmark = false;
-    this.ready = false;
     this.optionActive = undefined;
 
     /**
@@ -8776,7 +8666,6 @@ class AuroMenu extends r$6 {
       optionSelected: { type: Object },
       optionActive:   { type: Object },
       matchWord:      { type: String },
-      ready:          { type: Boolean },
       value:          { type: String }
     };
   }
@@ -9210,26 +9099,10 @@ class AuroMenu extends r$6 {
         this.index = this.items.indexOf(evt.target);
         this.updateActiveOption(this.index);
       });
-
-      this.notifyReady();
     } else {
       // make sure to update all menuoption noCheckmark attributes when the menu is dynamically changed
       this.handleNoCheckmarkAttr();
     }
-  }
-
-  /**
-   * @private
-   * @returns {void} Marks the component as ready and sends event.
-   */
-  notifyReady() {
-    this.ready = true;
-
-    this.dispatchEvent(new CustomEvent('auroMenu-ready', {
-      bubbles: true,
-      cancelable: false,
-      composed: true,
-    }));
   }
 
   render() {

--- a/components/combobox/demo/index.min.js
+++ b/components/combobox/demo/index.min.js
@@ -2975,7 +2975,6 @@ if (!customElements.get("auro-dropdownbib")) {
  * @csspart helpText - The helpText content container.
  * @csspart popover - The bib content container.
  * @event auroDropdown-triggerClick - Notifies that the trigger has been clicked.
- * @event auroDropdown-ready - Notifies that the component has finished initializing.
  * @event auroDropdown-toggled - Notifies that the visibility of the dropdown bib has changed.
  */
 class AuroDropdown extends r$5 {
@@ -3001,7 +3000,6 @@ class AuroDropdown extends r$5 {
     this.inset = false;
     this.placement = 'bottom-start';
     this.rounded = false;
-    this.ready = false;
     this.tabIndex = 0;
     this.noToggle = false;
 
@@ -3100,7 +3098,6 @@ class AuroDropdown extends r$5 {
         reflect: true
       },
       isPopoverVisible: { type: Boolean },
-      ready:            { type: Boolean },
       onSlotChange: {
         type: Function,
         reflect: false
@@ -3170,22 +3167,9 @@ class AuroDropdown extends r$5 {
     // Add the tag name as an attribute if it is different than the component name
     this.runtimeUtils.handleComponentTagRename(this, 'auro-dropdown');
 
-    this.notifyReady();
-  }
+    this.bibContent = this.shadowRoot.querySelector('auro-dropdownbib');
 
-  /**
-   * Marks the component as ready and sends event.
-   * @private
-   * @returns {void}
-   */
-  notifyReady() {
-    this.ready = true;
-
-    this.dispatchEvent(new CustomEvent('auroDropdown-ready', {
-      bubbles: true,
-      cancelable: false,
-      composed: true,
-    }));
+    document.body.append(this.bibContent);
   }
 
   /**
@@ -3267,7 +3251,7 @@ class AuroDropdown extends r$5 {
             <div class="triggerContent">
               <slot
                 name="trigger"
-                @slotchange="${() => {if (this.ready) this.floater.handleTriggerTabIndex(); }}"></slot>
+                @slotchange="${() => {this.floater.handleTriggerTabIndex(); }}"></slot>
             </div>
           </div>
           ${this.chevron || this.common ? u$1$1`
@@ -5374,7 +5358,6 @@ class AuroFormValidation {
  * @attr {String}  name - Populates the `name` attribute on the input.
  * @attr {Boolean} noValidate - If set, disables auto-validation on blur.
  * @attr {Boolean} readonly - Makes the input read-only, but can be set programmatically.
- * @prop {Boolean} ready - When false the component API should not be called.
  * @attr {Boolean} required - Populates the `required` attribute on the input. Used for client-side validation.
  * @attr {String}  pattern - Specifies a regular expression the form control's value should match.
  * @attr {String}  placeholder - Define custom placeholder text, only supported by date input formats.
@@ -5421,7 +5404,6 @@ class BaseInput extends r {
     this.maxLength = undefined;
     this.minLength = undefined;
     this.label = 'Input label is undefined';
-    this.ready = false;
     this.activeLabel = false;
 
     this.setCustomValidityForType = undefined;
@@ -5528,7 +5510,6 @@ class BaseInput extends r {
       showPassword:            { state: true },
       validateOnInput:         { type: Boolean },
       readonly:                { type: Boolean },
-      ready:                   { type: Boolean },
       error:                   {
         type: String,
         reflect: true
@@ -5767,8 +5748,6 @@ class BaseInput extends r {
         }
       }
     });
-
-    this.notifyReady();
   }
 
   /**
@@ -5867,20 +5846,6 @@ class BaseInput extends r {
    */
   notifyValidityChange() {
     this.dispatchEvent(new CustomEvent('auroInput-validityChange', {
-      bubbles: true,
-      cancelable: false,
-      composed: true,
-    }));
-  }
-
-  /**
-   * @private
-   * @returns {void} Marks the component as ready and sends event.
-   */
-  notifyReady() {
-    this.ready = true;
-
-    this.dispatchEvent(new CustomEvent('auroInput-ready', {
       bubbles: true,
       cancelable: false,
       composed: true,
@@ -7399,7 +7364,6 @@ var styleCss$3 = i$c`.util_displayInline{display:inline}.util_displayInlineBlock
  * @slot - Default slot for the menu content.
  * @slot label - Defines the content of the label.
  * @slot helpText - Defines the content of the helpText.
- * @event auroCombobox-ready - Notifies that the component has finished initializing.
  * @event auroCombobox-valueSet - Notifies that the component has a new value set.
  * @event auroFormElement-validated - Notifies that the component value(s) have been validated.
  */
@@ -7653,9 +7617,6 @@ class AuroCombobox extends r$6 {
     this.menuWrapper.append(this.menu);
 
     this.dropdown.setAttribute('role', 'combobox');
-    this.dropdown.addEventListener('auroDropdown-ready', () => {
-      this.auroDropdownReady = true;
-    });
 
     this.dropdown.addEventListener('auroDropdown-triggerClick', () => {
       this.showBib();
@@ -7691,15 +7652,6 @@ class AuroCombobox extends r$6 {
     } else {
       this.menu.setAttribute('nocheckmark', '');
     }
-
-    if (this.noFilter) {
-      this.auroMenuReady = true;
-    } else {
-      this.menu.addEventListener('auroMenu-ready', () => {
-        this.auroMenuReady = true;
-      });
-    }
-
 
     // handle the menu event for an option selection
     this.menu.addEventListener('auroMenu-selectedOption', () => {
@@ -7761,10 +7713,6 @@ class AuroCombobox extends r$6 {
    * @returns {void}
    */
   configureInput() {
-    this.input.addEventListener('auroInput-ready', () => {
-      this.auroInputReady = true;
-    });
-
     this.input.addEventListener('keyup', (evt) => {
       if (evt.key.length === 1 || evt.key === 'Backspace' || evt.key === 'Delete') {
         this.showBib();
@@ -7788,21 +7736,19 @@ class AuroCombobox extends r$6 {
       this.menu.matchWord = this.input.value;
       this.optionActive = null;
 
-      if (this.ready) {
-        if (this.value !== this.input.value) {
-          this.value = this.input.value;
-        }
-
-        if (this.value !== this.menu.value) {
-          this.menu.value = this.value;
-        }
-
-        if (this.optionSelected && this.input.value !== this.optionSelected.innerText) {
-          this.optionSelected = undefined;
-        }
-
-        this.menu.resetOptionsStates();
+      if (this.value !== this.input.value) {
+        this.value = this.input.value;
       }
+
+      if (this.value !== this.menu.value) {
+        this.menu.value = this.value;
+      }
+
+      if (this.optionSelected && this.input.value !== this.optionSelected.innerText) {
+        this.optionSelected = undefined;
+      }
+
+      this.menu.resetOptionsStates();
 
       this.handleMenuOptions();
 
@@ -7937,57 +7883,6 @@ class AuroCombobox extends r$6 {
     this.configureDropdown();
     this.configureCombobox();
 
-    this.checkReadiness();
-  }
-
-  /**
-   * @private
-   * @returns {void} Marks the component as ready and sends event.
-   */
-  notifyReady() {
-    this.ready = true;
-
-    this.dispatchEvent(new CustomEvent('auroCombobox-ready', {
-      bubbles: true,
-      cancelable: false,
-      composed: true,
-    }));
-  }
-
-  /**
-   * Monitors readiness of peer dependencies and begins work that should only start when ready.
-   * @private
-   * @returns {void}
-   */
-  checkReadiness() {
-    if (this.auroDropdownReady && this.auroInputReady && this.auroMenuReady) {
-      this.readyActions();
-      this.notifyReady();
-    } else {
-      // Start a retry counter to limit the retry count
-      if (!this.readyRetryCount && this.readyRetryCount !== 0) {
-        this.readyRetryCount = 0;
-      } else {
-        this.readyRetryCount += 1;
-      }
-
-      const readyTimer = 0;
-      const readyRetryLimit = 200;
-
-      if (this.readyRetryCount <= readyRetryLimit) {
-        setTimeout(() => {
-          this.checkReadiness();
-        }, readyTimer);
-      }
-    }
-  }
-
-  /**
-   * Functionality that should not be performed until the combobox is in a ready state.
-   * @private
-   * @returns {void}
-   */
-  readyActions() {
     // Set the initial value in auro-menu if defined
     if (this.hasAttribute('value') && this.getAttribute('value').length > 0) {
       this.menu.value = this.value;
@@ -8004,7 +7899,7 @@ class AuroCombobox extends r$6 {
 
   updated(changedProperties) {
     // After the component is ready, send direct value changes to auro-menu.
-    if (this.ready && changedProperties.has('value')) {
+    if (changedProperties.has('value')) {
       if (this.value) {
         if (this.optionSelected && this.optionSelected.value === this.value) {
           // If value updates and the previously selected option already matches the new value
@@ -8042,16 +7937,14 @@ class AuroCombobox extends r$6 {
    * @returns {void}
    */
   handleSlotChange() {
-    if (this.auroMenuReady) {
-      this.options = this.menu.querySelectorAll('auro-menuoption, [auro-menuoption]');
-      this.options.forEach((opt) => {
-        if (this.checkmark) {
-          opt.removeAttribute('nocheckmark');
-        } else {
-          opt.setAttribute('nocheckmark', '');
-        }
-      });
-    }
+    this.options = this.menu.querySelectorAll('auro-menuoption, [auro-menuoption]');
+    this.options.forEach((opt) => {
+      if (this.checkmark) {
+        opt.removeAttribute('nocheckmark');
+      } else {
+        opt.setAttribute('nocheckmark', '');
+      }
+    });
 
     this.handleMenuOptions();
   }
@@ -8632,7 +8525,6 @@ class AuroMenuOption extends r$6 {
  * @attr {Boolean} disabled - When true, the entire menu and all options are disabled;
  * @attr {Boolean} noCheckmark - When true, selected option will not show the checkmark.
  * @attr {String} value - Value selected for the menu.
- * @prop {Boolean} ready - When false the component API should not be called.
  * @event auroMenu-selectedOption - Notifies that a new menuoption selection has been made.
  * @event selectedOption - (DEPRECATED) Notifies that a new menuoption selection has been made.
  * @event auroMenu-activatedOption - Notifies that a menuoption has been made `active`.
@@ -8641,7 +8533,6 @@ class AuroMenuOption extends r$6 {
  * @event auroMenuSelectValueFailure - (DEPRECATED) Notifies that a an attempt to select a menuoption by matching a value has failed.
  * @event auroMenu-customEventFired - Notifies that a custom event has been fired.
  * @event auroMenuCustomEventFired - (DEPRECATED) Notifies that a custom event has been fired.
- * @event auroMenu-ready - Notifies that the component has finished initializing.
  * @event auroMenu-selectValueReset - Notifies that the component value has been reset.
  * @slot Slot for insertion of menu options.
  */
@@ -8655,7 +8546,6 @@ class AuroMenu extends r$6 {
     this.optionSelected = undefined;
     this.matchWord = undefined;
     this.noCheckmark = false;
-    this.ready = false;
     this.optionActive = undefined;
 
     /**
@@ -8687,7 +8577,6 @@ class AuroMenu extends r$6 {
       optionSelected: { type: Object },
       optionActive:   { type: Object },
       matchWord:      { type: String },
-      ready:          { type: Boolean },
       value:          { type: String }
     };
   }
@@ -9121,26 +9010,10 @@ class AuroMenu extends r$6 {
         this.index = this.items.indexOf(evt.target);
         this.updateActiveOption(this.index);
       });
-
-      this.notifyReady();
     } else {
       // make sure to update all menuoption noCheckmark attributes when the menu is dynamically changed
       this.handleNoCheckmarkAttr();
     }
-  }
-
-  /**
-   * @private
-   * @returns {void} Marks the component as ready and sends event.
-   */
-  notifyReady() {
-    this.ready = true;
-
-    this.dispatchEvent(new CustomEvent('auroMenu-ready', {
-      bubbles: true,
-      cancelable: false,
-      composed: true,
-    }));
   }
 
   render() {

--- a/components/combobox/docs/api.md
+++ b/components/combobox/docs/api.md
@@ -27,7 +27,6 @@
 
 | Event                       | Type               | Description                                      |
 |-----------------------------|--------------------|--------------------------------------------------|
-| `auroCombobox-ready`        | `CustomEvent<any>` | Notifies that the component has finished initializing. |
 | `auroCombobox-valueSet`     | `CustomEvent<any>` | Notifies that the component has a new value set. |
 | `auroFormElement-validated` |                    | Notifies that the component value(s) have been validated. |
 

--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -39,7 +39,6 @@ import styleCss from "./styles/style-css.js";
  * @slot - Default slot for the menu content.
  * @slot label - Defines the content of the label.
  * @slot helpText - Defines the content of the helpText.
- * @event auroCombobox-ready - Notifies that the component has finished initializing.
  * @event auroCombobox-valueSet - Notifies that the component has a new value set.
  * @event auroFormElement-validated - Notifies that the component value(s) have been validated.
  */
@@ -293,9 +292,6 @@ export class AuroCombobox extends LitElement {
     this.menuWrapper.append(this.menu);
 
     this.dropdown.setAttribute('role', 'combobox');
-    this.dropdown.addEventListener('auroDropdown-ready', () => {
-      this.auroDropdownReady = true;
-    });
 
     this.dropdown.addEventListener('auroDropdown-triggerClick', () => {
       this.showBib();
@@ -331,15 +327,6 @@ export class AuroCombobox extends LitElement {
     } else {
       this.menu.setAttribute('nocheckmark', '');
     }
-
-    if (this.noFilter) {
-      this.auroMenuReady = true;
-    } else {
-      this.menu.addEventListener('auroMenu-ready', () => {
-        this.auroMenuReady = true;
-      });
-    }
-
 
     // handle the menu event for an option selection
     this.menu.addEventListener('auroMenu-selectedOption', () => {
@@ -401,10 +388,6 @@ export class AuroCombobox extends LitElement {
    * @returns {void}
    */
   configureInput() {
-    this.input.addEventListener('auroInput-ready', () => {
-      this.auroInputReady = true;
-    });
-
     this.input.addEventListener('keyup', (evt) => {
       if (evt.key.length === 1 || evt.key === 'Backspace' || evt.key === 'Delete') {
         this.showBib();
@@ -428,21 +411,19 @@ export class AuroCombobox extends LitElement {
       this.menu.matchWord = this.input.value;
       this.optionActive = null;
 
-      if (this.ready) {
-        if (this.value !== this.input.value) {
-          this.value = this.input.value;
-        }
-
-        if (this.value !== this.menu.value) {
-          this.menu.value = this.value;
-        }
-
-        if (this.optionSelected && this.input.value !== this.optionSelected.innerText) {
-          this.optionSelected = undefined;
-        }
-
-        this.menu.resetOptionsStates();
+      if (this.value !== this.input.value) {
+        this.value = this.input.value;
       }
+
+      if (this.value !== this.menu.value) {
+        this.menu.value = this.value;
+      }
+
+      if (this.optionSelected && this.input.value !== this.optionSelected.innerText) {
+        this.optionSelected = undefined;
+      }
+
+      this.menu.resetOptionsStates();
 
       this.handleMenuOptions();
 
@@ -577,57 +558,6 @@ export class AuroCombobox extends LitElement {
     this.configureDropdown();
     this.configureCombobox();
 
-    this.checkReadiness();
-  }
-
-  /**
-   * @private
-   * @returns {void} Marks the component as ready and sends event.
-   */
-  notifyReady() {
-    this.ready = true;
-
-    this.dispatchEvent(new CustomEvent('auroCombobox-ready', {
-      bubbles: true,
-      cancelable: false,
-      composed: true,
-    }));
-  }
-
-  /**
-   * Monitors readiness of peer dependencies and begins work that should only start when ready.
-   * @private
-   * @returns {void}
-   */
-  checkReadiness() {
-    if (this.auroDropdownReady && this.auroInputReady && this.auroMenuReady) {
-      this.readyActions();
-      this.notifyReady();
-    } else {
-      // Start a retry counter to limit the retry count
-      if (!this.readyRetryCount && this.readyRetryCount !== 0) {
-        this.readyRetryCount = 0;
-      } else {
-        this.readyRetryCount += 1;
-      }
-
-      const readyTimer = 0;
-      const readyRetryLimit = 200;
-
-      if (this.readyRetryCount <= readyRetryLimit) {
-        setTimeout(() => {
-          this.checkReadiness();
-        }, readyTimer);
-      }
-    }
-  }
-
-  /**
-   * Functionality that should not be performed until the combobox is in a ready state.
-   * @private
-   * @returns {void}
-   */
-  readyActions() {
     // Set the initial value in auro-menu if defined
     if (this.hasAttribute('value') && this.getAttribute('value').length > 0) {
       this.menu.value = this.value;
@@ -644,7 +574,7 @@ export class AuroCombobox extends LitElement {
 
   updated(changedProperties) {
     // After the component is ready, send direct value changes to auro-menu.
-    if (this.ready && changedProperties.has('value')) {
+    if (changedProperties.has('value')) {
       if (this.value) {
         if (this.optionSelected && this.optionSelected.value === this.value) {
           // If value updates and the previously selected option already matches the new value
@@ -682,16 +612,14 @@ export class AuroCombobox extends LitElement {
    * @returns {void}
    */
   handleSlotChange() {
-    if (this.auroMenuReady) {
-      this.options = this.menu.querySelectorAll('auro-menuoption, [auro-menuoption]');
-      this.options.forEach((opt) => {
-        if (this.checkmark) {
-          opt.removeAttribute('nocheckmark');
-        } else {
-          opt.setAttribute('nocheckmark', '');
-        }
-      });
-    }
+    this.options = this.menu.querySelectorAll('auro-menuoption, [auro-menuoption]');
+    this.options.forEach((opt) => {
+      if (this.checkmark) {
+        opt.removeAttribute('nocheckmark');
+      } else {
+        opt.setAttribute('nocheckmark', '');
+      }
+    });
 
     this.handleMenuOptions();
   }

--- a/components/combobox/test/auro-combobox.test.js
+++ b/components/combobox/test/auro-combobox.test.js
@@ -84,7 +84,6 @@ describe('auro-combobox', () => {
 
   it('hides the bib when making a selection', async () => {
     const el = await defaultFixture();
-    await waitUntil(() => el.ready);
 
     const trigger = el.dropdown.querySelector('[slot="trigger"]');
 
@@ -142,7 +141,7 @@ describe('auro-combobox', () => {
 
   it('navigates menu with up and down arrow keys', async () => {
     const el = await defaultFixture();
-
+    el.focus();
     // Validate bib is shown when hitting enter but there is a value in the input
     setInputValue(el, 'pp');
     el.dispatchEvent(new KeyboardEvent('keydown', {
@@ -288,8 +287,6 @@ describe('auro-combobox', () => {
   it('makes a selection programmatically', async () => {
     const el = await defaultFixture();
 
-    await waitUntil(() => el.ready);
-
     const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
     const menu = dropdown.bibContent.querySelector('auro-menu')
     const menuOptions = menu.querySelectorAll('auro-menuoption');
@@ -311,7 +308,6 @@ describe('auro-combobox', () => {
 
   it('reset selection value programmatically', async () => {
     const el = await presetValueFixture();
-    await waitUntil(() => el.ready);
 
     el.value = undefined;
 
@@ -345,7 +341,6 @@ describe('auro-combobox', () => {
 
   it('Does not throw an error state when trying to programmatically set a value that doesn\'t match an option', async () => {
     const el = await defaultFixture();
-    await waitUntil(() => el.ready);
 
     const menu = el.querySelector('auro-menu')
 

--- a/components/datepicker/demo/api.min.js
+++ b/components/datepicker/demo/api.min.js
@@ -13230,7 +13230,6 @@ if (!customElements.get("auro-dropdownbib")) {
  * @csspart helpText - The helpText content container.
  * @csspart popover - The bib content container.
  * @event auroDropdown-triggerClick - Notifies that the trigger has been clicked.
- * @event auroDropdown-ready - Notifies that the component has finished initializing.
  * @event auroDropdown-toggled - Notifies that the visibility of the dropdown bib has changed.
  */
 class AuroDropdown extends r$5 {
@@ -13256,7 +13255,6 @@ class AuroDropdown extends r$5 {
     this.inset = false;
     this.placement = 'bottom-start';
     this.rounded = false;
-    this.ready = false;
     this.tabIndex = 0;
     this.noToggle = false;
 
@@ -13355,7 +13353,6 @@ class AuroDropdown extends r$5 {
         reflect: true
       },
       isPopoverVisible: { type: Boolean },
-      ready:            { type: Boolean },
       onSlotChange: {
         type: Function,
         reflect: false
@@ -13425,22 +13422,9 @@ class AuroDropdown extends r$5 {
     // Add the tag name as an attribute if it is different than the component name
     this.runtimeUtils.handleComponentTagRename(this, 'auro-dropdown');
 
-    this.notifyReady();
-  }
+    this.bibContent = this.shadowRoot.querySelector('auro-dropdownbib');
 
-  /**
-   * Marks the component as ready and sends event.
-   * @private
-   * @returns {void}
-   */
-  notifyReady() {
-    this.ready = true;
-
-    this.dispatchEvent(new CustomEvent('auroDropdown-ready', {
-      bubbles: true,
-      cancelable: false,
-      composed: true,
-    }));
+    document.body.append(this.bibContent);
   }
 
   /**
@@ -13522,7 +13506,7 @@ class AuroDropdown extends r$5 {
             <div class="triggerContent">
               <slot
                 name="trigger"
-                @slotchange="${() => {if (this.ready) this.floater.handleTriggerTabIndex(); }}"></slot>
+                @slotchange="${() => {this.floater.handleTriggerTabIndex(); }}"></slot>
             </div>
           </div>
           ${this.chevron || this.common ? u$1$1`
@@ -15629,7 +15613,6 @@ class AuroFormValidation {
  * @attr {String}  name - Populates the `name` attribute on the input.
  * @attr {Boolean} noValidate - If set, disables auto-validation on blur.
  * @attr {Boolean} readonly - Makes the input read-only, but can be set programmatically.
- * @prop {Boolean} ready - When false the component API should not be called.
  * @attr {Boolean} required - Populates the `required` attribute on the input. Used for client-side validation.
  * @attr {String}  pattern - Specifies a regular expression the form control's value should match.
  * @attr {String}  placeholder - Define custom placeholder text, only supported by date input formats.
@@ -15676,7 +15659,6 @@ class BaseInput extends r {
     this.maxLength = undefined;
     this.minLength = undefined;
     this.label = 'Input label is undefined';
-    this.ready = false;
     this.activeLabel = false;
 
     this.setCustomValidityForType = undefined;
@@ -15783,7 +15765,6 @@ class BaseInput extends r {
       showPassword:            { state: true },
       validateOnInput:         { type: Boolean },
       readonly:                { type: Boolean },
-      ready:                   { type: Boolean },
       error:                   {
         type: String,
         reflect: true
@@ -16022,8 +16003,6 @@ class BaseInput extends r {
         }
       }
     });
-
-    this.notifyReady();
   }
 
   /**
@@ -16122,20 +16101,6 @@ class BaseInput extends r {
    */
   notifyValidityChange() {
     this.dispatchEvent(new CustomEvent('auroInput-validityChange', {
-      bubbles: true,
-      cancelable: false,
-      composed: true,
-    }));
-  }
-
-  /**
-   * @private
-   * @returns {void} Marks the component as ready and sends event.
-   */
-  notifyReady() {
-    this.ready = true;
-
-    this.dispatchEvent(new CustomEvent('auroInput-ready', {
       bubbles: true,
       cancelable: false,
       composed: true,

--- a/components/datepicker/demo/index.min.js
+++ b/components/datepicker/demo/index.min.js
@@ -12985,7 +12985,6 @@ if (!customElements.get("auro-dropdownbib")) {
  * @csspart helpText - The helpText content container.
  * @csspart popover - The bib content container.
  * @event auroDropdown-triggerClick - Notifies that the trigger has been clicked.
- * @event auroDropdown-ready - Notifies that the component has finished initializing.
  * @event auroDropdown-toggled - Notifies that the visibility of the dropdown bib has changed.
  */
 class AuroDropdown extends r$5 {
@@ -13011,7 +13010,6 @@ class AuroDropdown extends r$5 {
     this.inset = false;
     this.placement = 'bottom-start';
     this.rounded = false;
-    this.ready = false;
     this.tabIndex = 0;
     this.noToggle = false;
 
@@ -13110,7 +13108,6 @@ class AuroDropdown extends r$5 {
         reflect: true
       },
       isPopoverVisible: { type: Boolean },
-      ready:            { type: Boolean },
       onSlotChange: {
         type: Function,
         reflect: false
@@ -13180,22 +13177,9 @@ class AuroDropdown extends r$5 {
     // Add the tag name as an attribute if it is different than the component name
     this.runtimeUtils.handleComponentTagRename(this, 'auro-dropdown');
 
-    this.notifyReady();
-  }
+    this.bibContent = this.shadowRoot.querySelector('auro-dropdownbib');
 
-  /**
-   * Marks the component as ready and sends event.
-   * @private
-   * @returns {void}
-   */
-  notifyReady() {
-    this.ready = true;
-
-    this.dispatchEvent(new CustomEvent('auroDropdown-ready', {
-      bubbles: true,
-      cancelable: false,
-      composed: true,
-    }));
+    document.body.append(this.bibContent);
   }
 
   /**
@@ -13277,7 +13261,7 @@ class AuroDropdown extends r$5 {
             <div class="triggerContent">
               <slot
                 name="trigger"
-                @slotchange="${() => {if (this.ready) this.floater.handleTriggerTabIndex(); }}"></slot>
+                @slotchange="${() => {this.floater.handleTriggerTabIndex(); }}"></slot>
             </div>
           </div>
           ${this.chevron || this.common ? u$1$1`
@@ -15384,7 +15368,6 @@ class AuroFormValidation {
  * @attr {String}  name - Populates the `name` attribute on the input.
  * @attr {Boolean} noValidate - If set, disables auto-validation on blur.
  * @attr {Boolean} readonly - Makes the input read-only, but can be set programmatically.
- * @prop {Boolean} ready - When false the component API should not be called.
  * @attr {Boolean} required - Populates the `required` attribute on the input. Used for client-side validation.
  * @attr {String}  pattern - Specifies a regular expression the form control's value should match.
  * @attr {String}  placeholder - Define custom placeholder text, only supported by date input formats.
@@ -15431,7 +15414,6 @@ class BaseInput extends r {
     this.maxLength = undefined;
     this.minLength = undefined;
     this.label = 'Input label is undefined';
-    this.ready = false;
     this.activeLabel = false;
 
     this.setCustomValidityForType = undefined;
@@ -15538,7 +15520,6 @@ class BaseInput extends r {
       showPassword:            { state: true },
       validateOnInput:         { type: Boolean },
       readonly:                { type: Boolean },
-      ready:                   { type: Boolean },
       error:                   {
         type: String,
         reflect: true
@@ -15777,8 +15758,6 @@ class BaseInput extends r {
         }
       }
     });
-
-    this.notifyReady();
   }
 
   /**
@@ -15877,20 +15856,6 @@ class BaseInput extends r {
    */
   notifyValidityChange() {
     this.dispatchEvent(new CustomEvent('auroInput-validityChange', {
-      bubbles: true,
-      cancelable: false,
-      composed: true,
-    }));
-  }
-
-  /**
-   * @private
-   * @returns {void} Marks the component as ready and sends event.
-   */
-  notifyReady() {
-    this.ready = true;
-
-    this.dispatchEvent(new CustomEvent('auroInput-ready', {
       bubbles: true,
       cancelable: false,
       composed: true,

--- a/components/dropdown/demo/api.md
+++ b/components/dropdown/demo/api.md
@@ -36,7 +36,6 @@
 
 | Event                       | Type                                  | Description                                      |
 |-----------------------------|---------------------------------------|--------------------------------------------------|
-| `auroDropdown-ready`        | `CustomEvent<any>`                    | Notifies that the component has finished initializing. |
 | `auroDropdown-toggled`      | `CustomEvent<{ expanded: boolean; }>` | Notifies that the visibility of the dropdown bib has changed. |
 | `auroDropdown-triggerClick` | `CustomEvent<any>`                    | Notifies that the trigger has been clicked.      |
 | [dropdownToggled](#dropdownToggled)           | `CustomEvent<{ expanded: boolean; }>` | (DEPRECATED) Notifies that the visibility of the dropdown bib has changed. |

--- a/components/dropdown/demo/api.min.js
+++ b/components/dropdown/demo/api.min.js
@@ -2522,7 +2522,6 @@ if (!customElements.get("auro-dropdownbib")) {
  * @csspart helpText - The helpText content container.
  * @csspart popover - The bib content container.
  * @event auroDropdown-triggerClick - Notifies that the trigger has been clicked.
- * @event auroDropdown-ready - Notifies that the component has finished initializing.
  * @event auroDropdown-toggled - Notifies that the visibility of the dropdown bib has changed.
  */
 class AuroDropdown extends r {
@@ -2548,7 +2547,6 @@ class AuroDropdown extends r {
     this.inset = false;
     this.placement = 'bottom-start';
     this.rounded = false;
-    this.ready = false;
     this.tabIndex = 0;
     this.noToggle = false;
 
@@ -2647,7 +2645,6 @@ class AuroDropdown extends r {
         reflect: true
       },
       isPopoverVisible: { type: Boolean },
-      ready:            { type: Boolean },
       onSlotChange: {
         type: Function,
         reflect: false
@@ -2717,22 +2714,9 @@ class AuroDropdown extends r {
     // Add the tag name as an attribute if it is different than the component name
     this.runtimeUtils.handleComponentTagRename(this, 'auro-dropdown');
 
-    this.notifyReady();
-  }
+    this.bibContent = this.shadowRoot.querySelector('auro-dropdownbib');
 
-  /**
-   * Marks the component as ready and sends event.
-   * @private
-   * @returns {void}
-   */
-  notifyReady() {
-    this.ready = true;
-
-    this.dispatchEvent(new CustomEvent('auroDropdown-ready', {
-      bubbles: true,
-      cancelable: false,
-      composed: true,
-    }));
+    document.body.append(this.bibContent);
   }
 
   /**
@@ -2814,7 +2798,7 @@ class AuroDropdown extends r {
             <div class="triggerContent">
               <slot
                 name="trigger"
-                @slotchange="${() => {if (this.ready) this.floater.handleTriggerTabIndex(); }}"></slot>
+                @slotchange="${() => {this.floater.handleTriggerTabIndex(); }}"></slot>
             </div>
           </div>
           ${this.chevron || this.common ? u$1`

--- a/components/dropdown/demo/index.min.js
+++ b/components/dropdown/demo/index.min.js
@@ -2504,7 +2504,6 @@ if (!customElements.get("auro-dropdownbib")) {
  * @csspart helpText - The helpText content container.
  * @csspart popover - The bib content container.
  * @event auroDropdown-triggerClick - Notifies that the trigger has been clicked.
- * @event auroDropdown-ready - Notifies that the component has finished initializing.
  * @event auroDropdown-toggled - Notifies that the visibility of the dropdown bib has changed.
  */
 class AuroDropdown extends r {
@@ -2530,7 +2529,6 @@ class AuroDropdown extends r {
     this.inset = false;
     this.placement = 'bottom-start';
     this.rounded = false;
-    this.ready = false;
     this.tabIndex = 0;
     this.noToggle = false;
 
@@ -2629,7 +2627,6 @@ class AuroDropdown extends r {
         reflect: true
       },
       isPopoverVisible: { type: Boolean },
-      ready:            { type: Boolean },
       onSlotChange: {
         type: Function,
         reflect: false
@@ -2699,22 +2696,9 @@ class AuroDropdown extends r {
     // Add the tag name as an attribute if it is different than the component name
     this.runtimeUtils.handleComponentTagRename(this, 'auro-dropdown');
 
-    this.notifyReady();
-  }
+    this.bibContent = this.shadowRoot.querySelector('auro-dropdownbib');
 
-  /**
-   * Marks the component as ready and sends event.
-   * @private
-   * @returns {void}
-   */
-  notifyReady() {
-    this.ready = true;
-
-    this.dispatchEvent(new CustomEvent('auroDropdown-ready', {
-      bubbles: true,
-      cancelable: false,
-      composed: true,
-    }));
+    document.body.append(this.bibContent);
   }
 
   /**
@@ -2796,7 +2780,7 @@ class AuroDropdown extends r {
             <div class="triggerContent">
               <slot
                 name="trigger"
-                @slotchange="${() => {if (this.ready) this.floater.handleTriggerTabIndex(); }}"></slot>
+                @slotchange="${() => {this.floater.handleTriggerTabIndex(); }}"></slot>
             </div>
           </div>
           ${this.chevron || this.common ? u$1`

--- a/components/dropdown/docs/api.md
+++ b/components/dropdown/docs/api.md
@@ -33,7 +33,6 @@
 
 | Event                       | Type                                  | Description                                      |
 |-----------------------------|---------------------------------------|--------------------------------------------------|
-| `auroDropdown-ready`        | `CustomEvent<any>`                    | Notifies that the component has finished initializing. |
 | `auroDropdown-toggled`      | `CustomEvent<{ expanded: boolean; }>` | Notifies that the visibility of the dropdown bib has changed. |
 | `auroDropdown-triggerClick` | `CustomEvent<any>`                    | Notifies that the trigger has been clicked.      |
 | `dropdownToggled`           | `CustomEvent<{ expanded: boolean; }>` | (DEPRECATED) Notifies that the visibility of the dropdown bib has changed. |

--- a/components/dropdown/src/auro-dropdown.js
+++ b/components/dropdown/src/auro-dropdown.js
@@ -48,7 +48,6 @@ import './auro-dropdownBib.js';
  * @csspart helpText - The helpText content container.
  * @csspart popover - The bib content container.
  * @event auroDropdown-triggerClick - Notifies that the trigger has been clicked.
- * @event auroDropdown-ready - Notifies that the component has finished initializing.
  * @event auroDropdown-toggled - Notifies that the visibility of the dropdown bib has changed.
  */
 export class AuroDropdown extends LitElement {
@@ -74,7 +73,6 @@ export class AuroDropdown extends LitElement {
     this.inset = false;
     this.placement = 'bottom-start';
     this.rounded = false;
-    this.ready = false;
     this.tabIndex = 0;
     this.noToggle = false;
 
@@ -173,7 +171,6 @@ export class AuroDropdown extends LitElement {
         reflect: true
       },
       isPopoverVisible: { type: Boolean },
-      ready:            { type: Boolean },
       onSlotChange: {
         type: Function,
         reflect: false
@@ -243,22 +240,9 @@ export class AuroDropdown extends LitElement {
     // Add the tag name as an attribute if it is different than the component name
     this.runtimeUtils.handleComponentTagRename(this, 'auro-dropdown');
 
-    this.notifyReady();
-  }
+    this.bibContent = this.shadowRoot.querySelector('auro-dropdownbib');
 
-  /**
-   * Marks the component as ready and sends event.
-   * @private
-   * @returns {void}
-   */
-  notifyReady() {
-    this.ready = true;
-
-    this.dispatchEvent(new CustomEvent('auroDropdown-ready', {
-      bubbles: true,
-      cancelable: false,
-      composed: true,
-    }));
+    document.body.append(this.bibContent);
   }
 
   /**
@@ -342,7 +326,7 @@ export class AuroDropdown extends LitElement {
             <div class="triggerContent">
               <slot
                 name="trigger"
-                @slotchange="${() => {if (this.ready) this.floater.handleTriggerTabIndex(); }}"></slot>
+                @slotchange="${() => {this.floater.handleTriggerTabIndex(); }}"></slot>
             </div>
           </div>
           ${this.chevron || this.common ? html`

--- a/components/input/demo/api.md
+++ b/components/input/demo/api.md
@@ -82,7 +82,6 @@
 | Event                       | Type               | Description                                      |
 |-----------------------------|--------------------|--------------------------------------------------|
 | `auroFormElement-validated` |                    | Notifies that the `validity` and `errorMessage` value has changed. |
-| `auroInput-ready`           | `CustomEvent<any>` |                                                  |
 | `auroInput-validityChange`  | `CustomEvent<any>` |                                                  |
 | [input](#input)                     |                    | Event fires when the value of an `auro-input` has been changed. |
 

--- a/components/input/demo/api.min.js
+++ b/components/input/demo/api.min.js
@@ -2134,7 +2134,6 @@ class AuroFormValidation {
  * @attr {String}  name - Populates the `name` attribute on the input.
  * @attr {Boolean} noValidate - If set, disables auto-validation on blur.
  * @attr {Boolean} readonly - Makes the input read-only, but can be set programmatically.
- * @prop {Boolean} ready - When false the component API should not be called.
  * @attr {Boolean} required - Populates the `required` attribute on the input. Used for client-side validation.
  * @attr {String}  pattern - Specifies a regular expression the form control's value should match.
  * @attr {String}  placeholder - Define custom placeholder text, only supported by date input formats.
@@ -2181,7 +2180,6 @@ class BaseInput extends r {
     this.maxLength = undefined;
     this.minLength = undefined;
     this.label = 'Input label is undefined';
-    this.ready = false;
     this.activeLabel = false;
 
     this.setCustomValidityForType = undefined;
@@ -2288,7 +2286,6 @@ class BaseInput extends r {
       showPassword:            { state: true },
       validateOnInput:         { type: Boolean },
       readonly:                { type: Boolean },
-      ready:                   { type: Boolean },
       error:                   {
         type: String,
         reflect: true
@@ -2527,8 +2524,6 @@ class BaseInput extends r {
         }
       }
     });
-
-    this.notifyReady();
   }
 
   /**
@@ -2627,20 +2622,6 @@ class BaseInput extends r {
    */
   notifyValidityChange() {
     this.dispatchEvent(new CustomEvent('auroInput-validityChange', {
-      bubbles: true,
-      cancelable: false,
-      composed: true,
-    }));
-  }
-
-  /**
-   * @private
-   * @returns {void} Marks the component as ready and sends event.
-   */
-  notifyReady() {
-    this.ready = true;
-
-    this.dispatchEvent(new CustomEvent('auroInput-ready', {
       bubbles: true,
       cancelable: false,
       composed: true,

--- a/components/input/demo/index.min.js
+++ b/components/input/demo/index.min.js
@@ -2080,7 +2080,6 @@ class AuroFormValidation {
  * @attr {String}  name - Populates the `name` attribute on the input.
  * @attr {Boolean} noValidate - If set, disables auto-validation on blur.
  * @attr {Boolean} readonly - Makes the input read-only, but can be set programmatically.
- * @prop {Boolean} ready - When false the component API should not be called.
  * @attr {Boolean} required - Populates the `required` attribute on the input. Used for client-side validation.
  * @attr {String}  pattern - Specifies a regular expression the form control's value should match.
  * @attr {String}  placeholder - Define custom placeholder text, only supported by date input formats.
@@ -2127,7 +2126,6 @@ class BaseInput extends r {
     this.maxLength = undefined;
     this.minLength = undefined;
     this.label = 'Input label is undefined';
-    this.ready = false;
     this.activeLabel = false;
 
     this.setCustomValidityForType = undefined;
@@ -2234,7 +2232,6 @@ class BaseInput extends r {
       showPassword:            { state: true },
       validateOnInput:         { type: Boolean },
       readonly:                { type: Boolean },
-      ready:                   { type: Boolean },
       error:                   {
         type: String,
         reflect: true
@@ -2473,8 +2470,6 @@ class BaseInput extends r {
         }
       }
     });
-
-    this.notifyReady();
   }
 
   /**
@@ -2573,20 +2568,6 @@ class BaseInput extends r {
    */
   notifyValidityChange() {
     this.dispatchEvent(new CustomEvent('auroInput-validityChange', {
-      bubbles: true,
-      cancelable: false,
-      composed: true,
-    }));
-  }
-
-  /**
-   * @private
-   * @returns {void} Marks the component as ready and sends event.
-   */
-  notifyReady() {
-    this.ready = true;
-
-    this.dispatchEvent(new CustomEvent('auroInput-ready', {
       bubbles: true,
       cancelable: false,
       composed: true,

--- a/components/input/docs/api.md
+++ b/components/input/docs/api.md
@@ -62,7 +62,6 @@
 | Event                       | Type               | Description                                      |
 |-----------------------------|--------------------|--------------------------------------------------|
 | `auroFormElement-validated` |                    | Notifies that the `validity` and `errorMessage` value has changed. |
-| `auroInput-ready`           | `CustomEvent<any>` |                                                  |
 | `auroInput-validityChange`  | `CustomEvent<any>` |                                                  |
 | `input`                     |                    | Event fires when the value of an `auro-input` has been changed. |
 

--- a/components/input/src/base-input.js
+++ b/components/input/src/base-input.js
@@ -42,7 +42,6 @@ import AuroFormValidation from '@aurodesignsystem/auro-formvalidation/src/valida
  * @attr {String}  name - Populates the `name` attribute on the input.
  * @attr {Boolean} noValidate - If set, disables auto-validation on blur.
  * @attr {Boolean} readonly - Makes the input read-only, but can be set programmatically.
- * @prop {Boolean} ready - When false the component API should not be called.
  * @attr {Boolean} required - Populates the `required` attribute on the input. Used for client-side validation.
  * @attr {String}  pattern - Specifies a regular expression the form control's value should match.
  * @attr {String}  placeholder - Define custom placeholder text, only supported by date input formats.
@@ -89,7 +88,6 @@ export default class BaseInput extends LitElement {
     this.maxLength = undefined;
     this.minLength = undefined;
     this.label = 'Input label is undefined';
-    this.ready = false;
     this.activeLabel = false;
 
     this.setCustomValidityForType = undefined;
@@ -196,7 +194,6 @@ export default class BaseInput extends LitElement {
       showPassword:            { state: true },
       validateOnInput:         { type: Boolean },
       readonly:                { type: Boolean },
-      ready:                   { type: Boolean },
       error:                   {
         type: String,
         reflect: true
@@ -437,8 +434,6 @@ export default class BaseInput extends LitElement {
         }
       }
     });
-
-    this.notifyReady();
   }
 
   /**
@@ -537,20 +532,6 @@ export default class BaseInput extends LitElement {
    */
   notifyValidityChange() {
     this.dispatchEvent(new CustomEvent('auroInput-validityChange', {
-      bubbles: true,
-      cancelable: false,
-      composed: true,
-    }));
-  }
-
-  /**
-   * @private
-   * @returns {void} Marks the component as ready and sends event.
-   */
-  notifyReady() {
-    this.ready = true;
-
-    this.dispatchEvent(new CustomEvent('auroInput-ready', {
       bubbles: true,
       cancelable: false,
       composed: true,

--- a/components/menu/demo/api.md
+++ b/components/menu/demo/api.md
@@ -31,7 +31,6 @@ The auro-menu element provides users a way to select from a list of options.
 |-------------------------------|------------------------|--------------------------------------------------|
 | `auroMenu-activatedOption`    | `CustomEvent<Element>` | Notifies that a menuoption has been made `active`. |
 | `auroMenu-customEventFired`   | `CustomEvent<any>`     | Notifies that a custom event has been fired.     |
-| `auroMenu-ready`              | `CustomEvent<any>`     | Notifies that the component has finished initializing. |
 | `auroMenu-selectValueFailure` | `CustomEvent<any>`     | Notifies that a an attempt to select a menuoption by matching a value has failed. |
 | `auroMenu-selectValueReset`   | `CustomEvent<any>`     | Notifies that the component value has been reset. |
 | `auroMenu-selectedOption`     | `CustomEvent<any>`     | Notifies that a new menuoption selection has been made. |

--- a/components/menu/demo/api.min.js
+++ b/components/menu/demo/api.min.js
@@ -702,7 +702,6 @@ class AuroMenuOption extends r {
  * @attr {Boolean} disabled - When true, the entire menu and all options are disabled;
  * @attr {Boolean} noCheckmark - When true, selected option will not show the checkmark.
  * @attr {String} value - Value selected for the menu.
- * @prop {Boolean} ready - When false the component API should not be called.
  * @event auroMenu-selectedOption - Notifies that a new menuoption selection has been made.
  * @event selectedOption - (DEPRECATED) Notifies that a new menuoption selection has been made.
  * @event auroMenu-activatedOption - Notifies that a menuoption has been made `active`.
@@ -711,7 +710,6 @@ class AuroMenuOption extends r {
  * @event auroMenuSelectValueFailure - (DEPRECATED) Notifies that a an attempt to select a menuoption by matching a value has failed.
  * @event auroMenu-customEventFired - Notifies that a custom event has been fired.
  * @event auroMenuCustomEventFired - (DEPRECATED) Notifies that a custom event has been fired.
- * @event auroMenu-ready - Notifies that the component has finished initializing.
  * @event auroMenu-selectValueReset - Notifies that the component value has been reset.
  * @slot Slot for insertion of menu options.
  */
@@ -725,7 +723,6 @@ class AuroMenu extends r {
     this.optionSelected = undefined;
     this.matchWord = undefined;
     this.noCheckmark = false;
-    this.ready = false;
     this.optionActive = undefined;
 
     /**
@@ -757,7 +754,6 @@ class AuroMenu extends r {
       optionSelected: { type: Object },
       optionActive:   { type: Object },
       matchWord:      { type: String },
-      ready:          { type: Boolean },
       value:          { type: String }
     };
   }
@@ -1191,26 +1187,10 @@ class AuroMenu extends r {
         this.index = this.items.indexOf(evt.target);
         this.updateActiveOption(this.index);
       });
-
-      this.notifyReady();
     } else {
       // make sure to update all menuoption noCheckmark attributes when the menu is dynamically changed
       this.handleNoCheckmarkAttr();
     }
-  }
-
-  /**
-   * @private
-   * @returns {void} Marks the component as ready and sends event.
-   */
-  notifyReady() {
-    this.ready = true;
-
-    this.dispatchEvent(new CustomEvent('auroMenu-ready', {
-      bubbles: true,
-      cancelable: false,
-      composed: true,
-    }));
   }
 
   render() {

--- a/components/menu/demo/index.min.js
+++ b/components/menu/demo/index.min.js
@@ -668,7 +668,6 @@ class AuroMenuOption extends r {
  * @attr {Boolean} disabled - When true, the entire menu and all options are disabled;
  * @attr {Boolean} noCheckmark - When true, selected option will not show the checkmark.
  * @attr {String} value - Value selected for the menu.
- * @prop {Boolean} ready - When false the component API should not be called.
  * @event auroMenu-selectedOption - Notifies that a new menuoption selection has been made.
  * @event selectedOption - (DEPRECATED) Notifies that a new menuoption selection has been made.
  * @event auroMenu-activatedOption - Notifies that a menuoption has been made `active`.
@@ -677,7 +676,6 @@ class AuroMenuOption extends r {
  * @event auroMenuSelectValueFailure - (DEPRECATED) Notifies that a an attempt to select a menuoption by matching a value has failed.
  * @event auroMenu-customEventFired - Notifies that a custom event has been fired.
  * @event auroMenuCustomEventFired - (DEPRECATED) Notifies that a custom event has been fired.
- * @event auroMenu-ready - Notifies that the component has finished initializing.
  * @event auroMenu-selectValueReset - Notifies that the component value has been reset.
  * @slot Slot for insertion of menu options.
  */
@@ -691,7 +689,6 @@ class AuroMenu extends r {
     this.optionSelected = undefined;
     this.matchWord = undefined;
     this.noCheckmark = false;
-    this.ready = false;
     this.optionActive = undefined;
 
     /**
@@ -723,7 +720,6 @@ class AuroMenu extends r {
       optionSelected: { type: Object },
       optionActive:   { type: Object },
       matchWord:      { type: String },
-      ready:          { type: Boolean },
       value:          { type: String }
     };
   }
@@ -1157,26 +1153,10 @@ class AuroMenu extends r {
         this.index = this.items.indexOf(evt.target);
         this.updateActiveOption(this.index);
       });
-
-      this.notifyReady();
     } else {
       // make sure to update all menuoption noCheckmark attributes when the menu is dynamically changed
       this.handleNoCheckmarkAttr();
     }
-  }
-
-  /**
-   * @private
-   * @returns {void} Marks the component as ready and sends event.
-   */
-  notifyReady() {
-    this.ready = true;
-
-    this.dispatchEvent(new CustomEvent('auroMenu-ready', {
-      bubbles: true,
-      cancelable: false,
-      composed: true,
-    }));
   }
 
   render() {

--- a/components/menu/docs/api.md
+++ b/components/menu/docs/api.md
@@ -28,7 +28,6 @@ The auro-menu element provides users a way to select from a list of options.
 |-------------------------------|------------------------|--------------------------------------------------|
 | `auroMenu-activatedOption`    | `CustomEvent<Element>` | Notifies that a menuoption has been made `active`. |
 | `auroMenu-customEventFired`   | `CustomEvent<any>`     | Notifies that a custom event has been fired.     |
-| `auroMenu-ready`              | `CustomEvent<any>`     | Notifies that the component has finished initializing. |
 | `auroMenu-selectValueFailure` | `CustomEvent<any>`     | Notifies that a an attempt to select a menuoption by matching a value has failed. |
 | `auroMenu-selectValueReset`   | `CustomEvent<any>`     | Notifies that the component value has been reset. |
 | `auroMenu-selectedOption`     | `CustomEvent<any>`     | Notifies that a new menuoption selection has been made. |

--- a/components/menu/src/auro-menu.js
+++ b/components/menu/src/auro-menu.js
@@ -21,7 +21,6 @@ import './auro-menuoption.js';
  * @attr {Boolean} disabled - When true, the entire menu and all options are disabled;
  * @attr {Boolean} noCheckmark - When true, selected option will not show the checkmark.
  * @attr {String} value - Value selected for the menu.
- * @prop {Boolean} ready - When false the component API should not be called.
  * @event auroMenu-selectedOption - Notifies that a new menuoption selection has been made.
  * @event selectedOption - (DEPRECATED) Notifies that a new menuoption selection has been made.
  * @event auroMenu-activatedOption - Notifies that a menuoption has been made `active`.
@@ -30,7 +29,6 @@ import './auro-menuoption.js';
  * @event auroMenuSelectValueFailure - (DEPRECATED) Notifies that a an attempt to select a menuoption by matching a value has failed.
  * @event auroMenu-customEventFired - Notifies that a custom event has been fired.
  * @event auroMenuCustomEventFired - (DEPRECATED) Notifies that a custom event has been fired.
- * @event auroMenu-ready - Notifies that the component has finished initializing.
  * @event auroMenu-selectValueReset - Notifies that the component value has been reset.
  * @slot Slot for insertion of menu options.
  */
@@ -44,7 +42,6 @@ export class AuroMenu extends LitElement {
     this.optionSelected = undefined;
     this.matchWord = undefined;
     this.noCheckmark = false;
-    this.ready = false;
     this.optionActive = undefined;
 
     /**
@@ -76,7 +73,6 @@ export class AuroMenu extends LitElement {
       optionSelected: { type: Object },
       optionActive:   { type: Object },
       matchWord:      { type: String },
-      ready:          { type: Boolean },
       value:          { type: String }
     };
   }
@@ -512,26 +508,10 @@ export class AuroMenu extends LitElement {
         this.index = this.items.indexOf(evt.target);
         this.updateActiveOption(this.index);
       });
-
-      this.notifyReady();
     } else {
       // make sure to update all menuoption noCheckmark attributes when the menu is dynamically changed
       this.handleNoCheckmarkAttr();
     }
-  }
-
-  /**
-   * @private
-   * @returns {void} Marks the component as ready and sends event.
-   */
-  notifyReady() {
-    this.ready = true;
-
-    this.dispatchEvent(new CustomEvent('auroMenu-ready', {
-      bubbles: true,
-      cancelable: false,
-      composed: true,
-    }));
   }
 
   render() {

--- a/components/select/demo/api.md
+++ b/components/select/demo/api.md
@@ -35,7 +35,6 @@ The auro-select element is a wrapper for auro-dropdown and auro-menu to create a
 | Event                       | Type               | Description                                      |
 |-----------------------------|--------------------|--------------------------------------------------|
 | `auroFormElement-validated` |                    | Notifies that the `validity` and `errorMessage` values have changed. |
-| `auroSelect-ready`          | `CustomEvent<any>` | Notifies that the component has finished initializing. |
 | `auroSelect-valueSet`       | `CustomEvent<any>` | Notifies that the component has a new value set. |
 
 ## Slots

--- a/components/select/demo/api.min.js
+++ b/components/select/demo/api.min.js
@@ -3004,7 +3004,6 @@ if (!customElements.get("auro-dropdownbib")) {
  * @csspart helpText - The helpText content container.
  * @csspart popover - The bib content container.
  * @event auroDropdown-triggerClick - Notifies that the trigger has been clicked.
- * @event auroDropdown-ready - Notifies that the component has finished initializing.
  * @event auroDropdown-toggled - Notifies that the visibility of the dropdown bib has changed.
  */
 class AuroDropdown extends r {
@@ -3030,7 +3029,6 @@ class AuroDropdown extends r {
     this.inset = false;
     this.placement = 'bottom-start';
     this.rounded = false;
-    this.ready = false;
     this.tabIndex = 0;
     this.noToggle = false;
 
@@ -3129,7 +3127,6 @@ class AuroDropdown extends r {
         reflect: true
       },
       isPopoverVisible: { type: Boolean },
-      ready:            { type: Boolean },
       onSlotChange: {
         type: Function,
         reflect: false
@@ -3199,22 +3196,9 @@ class AuroDropdown extends r {
     // Add the tag name as an attribute if it is different than the component name
     this.runtimeUtils.handleComponentTagRename(this, 'auro-dropdown');
 
-    this.notifyReady();
-  }
+    this.bibContent = this.shadowRoot.querySelector('auro-dropdownbib');
 
-  /**
-   * Marks the component as ready and sends event.
-   * @private
-   * @returns {void}
-   */
-  notifyReady() {
-    this.ready = true;
-
-    this.dispatchEvent(new CustomEvent('auroDropdown-ready', {
-      bubbles: true,
-      cancelable: false,
-      composed: true,
-    }));
+    document.body.append(this.bibContent);
   }
 
   /**
@@ -3296,7 +3280,7 @@ class AuroDropdown extends r {
             <div class="triggerContent">
               <slot
                 name="trigger"
-                @slotchange="${() => {if (this.ready) this.floater.handleTriggerTabIndex(); }}"></slot>
+                @slotchange="${() => {this.floater.handleTriggerTabIndex(); }}"></slot>
             </div>
           </div>
           ${this.chevron || this.common ? u$1`
@@ -3368,7 +3352,6 @@ var tokensCss$2 = i$b`:host{--ds-auro-select-placeholder-text-color: var(--ds-co
  * @slot - Default slot for the menu content.
  * @slot label - Defines the content of the label.
  * @slot helpText - Defines the content of the helpText.
- * @event auroSelect-ready - Notifies that the component has finished initializing.
  * @event auroSelect-valueSet - Notifies that the component has a new value set.
  * @event auroFormElement-validated - Notifies that the `validity` and `errorMessage` values have changed.
  * @csspart helpText - Apply CSS to the help text.
@@ -3511,10 +3494,6 @@ class AuroSelect extends r$4 {
 
     // Exposes the CSS parts from the dropdown for styling
     this.dropdown.exposeCssParts();
-
-    this.dropdown.addEventListener('auroDropdown-ready', () => {
-      this.auroDropdownReady = true;
-    });
   }
 
   /**
@@ -3580,10 +3559,6 @@ class AuroSelect extends r$4 {
     this.menu.setAttribute('aria-hidden', 'true');
 
     this.generateOptionsArray();
-
-    this.menu.addEventListener('auroMenu-ready', () => {
-      this.auroMenuReady = true;
-    });
 
     this.addEventListener('auroMenu-activatedOption', (evt) => {
       this.optionActive = evt.detail;
@@ -3702,51 +3677,6 @@ class AuroSelect extends r$4 {
   }
 
   /**
-   * Marks the component as ready and sends event.
-   * @private
-   * @returns {void}
-   */
-  notifyReady() {
-    this.ready = true;
-
-    this.dispatchEvent(new CustomEvent('auroSelect-ready', {
-      bubbles: true,
-      cancelable: false,
-      composed: true,
-    }));
-  }
-
-  /**
-   * Monitors readiness of peer dependencies and begins work that should only start when ready.
-   * @private
-   * @returns {void}
-   */
-  async checkReadiness() {
-    if (this.auroDropdownReady && this.auroMenuReady) {
-      this.readyActions();
-      this.notifyReady();
-    } else {
-      // Start a retry counter to limit the retry count
-      if (!this.readyRetryCount && this.readyRetryCount !== 0) {
-        this.readyRetryCount = 0;
-      } else {
-        this.readyRetryCount += 1;
-      }
-
-      const readyTimer = 0;
-      const readyRetryLimit = 200;
-
-      if (this.readyRetryCount <= readyRetryLimit) {
-
-        const sleep = (time) => new Promise((resolve) => setTimeout(resolve, time));
-
-        await sleep(readyTimer);
-        this.checkReadiness();
-      }
-    }
-  }
-
-  /**
    * Determines the element error state based on the `required` attribute and input value.
    * @private
    * @returns {void}
@@ -3756,18 +3686,6 @@ class AuroSelect extends r$4 {
       this.options = [...this.menu.querySelectorAll('auro-menuoption, [auro-menuoption]')];
     } else {
       this.options = [];
-    }
-  }
-
-  /**
-   * Functionality that should not be performed until the combobox is in a ready state.
-   * @private
-   * @returns {void}
-   */
-  readyActions() {
-    // Set the initial value in auro-menu if defined
-    if (this.hasAttribute('value') && this.getAttribute('value').length > 0) {
-      this.menu.value = this.value;
     }
   }
 
@@ -3805,24 +3723,23 @@ class AuroSelect extends r$4 {
     this.configureDropdown();
     this.configureSelect();
 
-    this.checkReadiness();
+    // Set the initial value in auro-menu if defined
+    if (this.hasAttribute('value') && this.getAttribute('value').length > 0) {
+      this.menu.value = this.value;
+    }
   }
 
   updated(changedProperties) {
     // After the component is ready, send direct value changes to auro-menu.
-    if (this.ready && changedProperties.has('value')) {
+    if (changedProperties.has('value')) {
       if (this.value) {
         this.menu.value = this.value;
       } else {
         this.menu.value = undefined;
       }
-    }
 
-    if (changedProperties.has('value')) {
       this.validation.validate(this);
-    }
 
-    if (changedProperties.has('value')) {
       this.dispatchEvent(new CustomEvent('auroSelect-valueSet', {
         bubbles: true,
         cancelable: false,
@@ -4457,7 +4374,6 @@ class AuroMenuOption extends r$4 {
  * @attr {Boolean} disabled - When true, the entire menu and all options are disabled;
  * @attr {Boolean} noCheckmark - When true, selected option will not show the checkmark.
  * @attr {String} value - Value selected for the menu.
- * @prop {Boolean} ready - When false the component API should not be called.
  * @event auroMenu-selectedOption - Notifies that a new menuoption selection has been made.
  * @event selectedOption - (DEPRECATED) Notifies that a new menuoption selection has been made.
  * @event auroMenu-activatedOption - Notifies that a menuoption has been made `active`.
@@ -4466,7 +4382,6 @@ class AuroMenuOption extends r$4 {
  * @event auroMenuSelectValueFailure - (DEPRECATED) Notifies that a an attempt to select a menuoption by matching a value has failed.
  * @event auroMenu-customEventFired - Notifies that a custom event has been fired.
  * @event auroMenuCustomEventFired - (DEPRECATED) Notifies that a custom event has been fired.
- * @event auroMenu-ready - Notifies that the component has finished initializing.
  * @event auroMenu-selectValueReset - Notifies that the component value has been reset.
  * @slot Slot for insertion of menu options.
  */
@@ -4480,7 +4395,6 @@ class AuroMenu extends r$4 {
     this.optionSelected = undefined;
     this.matchWord = undefined;
     this.noCheckmark = false;
-    this.ready = false;
     this.optionActive = undefined;
 
     /**
@@ -4512,7 +4426,6 @@ class AuroMenu extends r$4 {
       optionSelected: { type: Object },
       optionActive:   { type: Object },
       matchWord:      { type: String },
-      ready:          { type: Boolean },
       value:          { type: String }
     };
   }
@@ -4946,26 +4859,10 @@ class AuroMenu extends r$4 {
         this.index = this.items.indexOf(evt.target);
         this.updateActiveOption(this.index);
       });
-
-      this.notifyReady();
     } else {
       // make sure to update all menuoption noCheckmark attributes when the menu is dynamically changed
       this.handleNoCheckmarkAttr();
     }
-  }
-
-  /**
-   * @private
-   * @returns {void} Marks the component as ready and sends event.
-   */
-  notifyReady() {
-    this.ready = true;
-
-    this.dispatchEvent(new CustomEvent('auroMenu-ready', {
-      bubbles: true,
-      cancelable: false,
-      composed: true,
-    }));
   }
 
   render() {

--- a/components/select/demo/index.min.js
+++ b/components/select/demo/index.min.js
@@ -2952,7 +2952,6 @@ if (!customElements.get("auro-dropdownbib")) {
  * @csspart helpText - The helpText content container.
  * @csspart popover - The bib content container.
  * @event auroDropdown-triggerClick - Notifies that the trigger has been clicked.
- * @event auroDropdown-ready - Notifies that the component has finished initializing.
  * @event auroDropdown-toggled - Notifies that the visibility of the dropdown bib has changed.
  */
 class AuroDropdown extends r {
@@ -2978,7 +2977,6 @@ class AuroDropdown extends r {
     this.inset = false;
     this.placement = 'bottom-start';
     this.rounded = false;
-    this.ready = false;
     this.tabIndex = 0;
     this.noToggle = false;
 
@@ -3077,7 +3075,6 @@ class AuroDropdown extends r {
         reflect: true
       },
       isPopoverVisible: { type: Boolean },
-      ready:            { type: Boolean },
       onSlotChange: {
         type: Function,
         reflect: false
@@ -3147,22 +3144,9 @@ class AuroDropdown extends r {
     // Add the tag name as an attribute if it is different than the component name
     this.runtimeUtils.handleComponentTagRename(this, 'auro-dropdown');
 
-    this.notifyReady();
-  }
+    this.bibContent = this.shadowRoot.querySelector('auro-dropdownbib');
 
-  /**
-   * Marks the component as ready and sends event.
-   * @private
-   * @returns {void}
-   */
-  notifyReady() {
-    this.ready = true;
-
-    this.dispatchEvent(new CustomEvent('auroDropdown-ready', {
-      bubbles: true,
-      cancelable: false,
-      composed: true,
-    }));
+    document.body.append(this.bibContent);
   }
 
   /**
@@ -3244,7 +3228,7 @@ class AuroDropdown extends r {
             <div class="triggerContent">
               <slot
                 name="trigger"
-                @slotchange="${() => {if (this.ready) this.floater.handleTriggerTabIndex(); }}"></slot>
+                @slotchange="${() => {this.floater.handleTriggerTabIndex(); }}"></slot>
             </div>
           </div>
           ${this.chevron || this.common ? u$1`
@@ -3316,7 +3300,6 @@ var tokensCss$2 = i$b`:host{--ds-auro-select-placeholder-text-color: var(--ds-co
  * @slot - Default slot for the menu content.
  * @slot label - Defines the content of the label.
  * @slot helpText - Defines the content of the helpText.
- * @event auroSelect-ready - Notifies that the component has finished initializing.
  * @event auroSelect-valueSet - Notifies that the component has a new value set.
  * @event auroFormElement-validated - Notifies that the `validity` and `errorMessage` values have changed.
  * @csspart helpText - Apply CSS to the help text.
@@ -3459,10 +3442,6 @@ class AuroSelect extends r$4 {
 
     // Exposes the CSS parts from the dropdown for styling
     this.dropdown.exposeCssParts();
-
-    this.dropdown.addEventListener('auroDropdown-ready', () => {
-      this.auroDropdownReady = true;
-    });
   }
 
   /**
@@ -3528,10 +3507,6 @@ class AuroSelect extends r$4 {
     this.menu.setAttribute('aria-hidden', 'true');
 
     this.generateOptionsArray();
-
-    this.menu.addEventListener('auroMenu-ready', () => {
-      this.auroMenuReady = true;
-    });
 
     this.addEventListener('auroMenu-activatedOption', (evt) => {
       this.optionActive = evt.detail;
@@ -3650,51 +3625,6 @@ class AuroSelect extends r$4 {
   }
 
   /**
-   * Marks the component as ready and sends event.
-   * @private
-   * @returns {void}
-   */
-  notifyReady() {
-    this.ready = true;
-
-    this.dispatchEvent(new CustomEvent('auroSelect-ready', {
-      bubbles: true,
-      cancelable: false,
-      composed: true,
-    }));
-  }
-
-  /**
-   * Monitors readiness of peer dependencies and begins work that should only start when ready.
-   * @private
-   * @returns {void}
-   */
-  async checkReadiness() {
-    if (this.auroDropdownReady && this.auroMenuReady) {
-      this.readyActions();
-      this.notifyReady();
-    } else {
-      // Start a retry counter to limit the retry count
-      if (!this.readyRetryCount && this.readyRetryCount !== 0) {
-        this.readyRetryCount = 0;
-      } else {
-        this.readyRetryCount += 1;
-      }
-
-      const readyTimer = 0;
-      const readyRetryLimit = 200;
-
-      if (this.readyRetryCount <= readyRetryLimit) {
-
-        const sleep = (time) => new Promise((resolve) => setTimeout(resolve, time));
-
-        await sleep(readyTimer);
-        this.checkReadiness();
-      }
-    }
-  }
-
-  /**
    * Determines the element error state based on the `required` attribute and input value.
    * @private
    * @returns {void}
@@ -3704,18 +3634,6 @@ class AuroSelect extends r$4 {
       this.options = [...this.menu.querySelectorAll('auro-menuoption, [auro-menuoption]')];
     } else {
       this.options = [];
-    }
-  }
-
-  /**
-   * Functionality that should not be performed until the combobox is in a ready state.
-   * @private
-   * @returns {void}
-   */
-  readyActions() {
-    // Set the initial value in auro-menu if defined
-    if (this.hasAttribute('value') && this.getAttribute('value').length > 0) {
-      this.menu.value = this.value;
     }
   }
 
@@ -3753,24 +3671,23 @@ class AuroSelect extends r$4 {
     this.configureDropdown();
     this.configureSelect();
 
-    this.checkReadiness();
+    // Set the initial value in auro-menu if defined
+    if (this.hasAttribute('value') && this.getAttribute('value').length > 0) {
+      this.menu.value = this.value;
+    }
   }
 
   updated(changedProperties) {
     // After the component is ready, send direct value changes to auro-menu.
-    if (this.ready && changedProperties.has('value')) {
+    if (changedProperties.has('value')) {
       if (this.value) {
         this.menu.value = this.value;
       } else {
         this.menu.value = undefined;
       }
-    }
 
-    if (changedProperties.has('value')) {
       this.validation.validate(this);
-    }
 
-    if (changedProperties.has('value')) {
       this.dispatchEvent(new CustomEvent('auroSelect-valueSet', {
         bubbles: true,
         cancelable: false,
@@ -4405,7 +4322,6 @@ class AuroMenuOption extends r$4 {
  * @attr {Boolean} disabled - When true, the entire menu and all options are disabled;
  * @attr {Boolean} noCheckmark - When true, selected option will not show the checkmark.
  * @attr {String} value - Value selected for the menu.
- * @prop {Boolean} ready - When false the component API should not be called.
  * @event auroMenu-selectedOption - Notifies that a new menuoption selection has been made.
  * @event selectedOption - (DEPRECATED) Notifies that a new menuoption selection has been made.
  * @event auroMenu-activatedOption - Notifies that a menuoption has been made `active`.
@@ -4414,7 +4330,6 @@ class AuroMenuOption extends r$4 {
  * @event auroMenuSelectValueFailure - (DEPRECATED) Notifies that a an attempt to select a menuoption by matching a value has failed.
  * @event auroMenu-customEventFired - Notifies that a custom event has been fired.
  * @event auroMenuCustomEventFired - (DEPRECATED) Notifies that a custom event has been fired.
- * @event auroMenu-ready - Notifies that the component has finished initializing.
  * @event auroMenu-selectValueReset - Notifies that the component value has been reset.
  * @slot Slot for insertion of menu options.
  */
@@ -4428,7 +4343,6 @@ class AuroMenu extends r$4 {
     this.optionSelected = undefined;
     this.matchWord = undefined;
     this.noCheckmark = false;
-    this.ready = false;
     this.optionActive = undefined;
 
     /**
@@ -4460,7 +4374,6 @@ class AuroMenu extends r$4 {
       optionSelected: { type: Object },
       optionActive:   { type: Object },
       matchWord:      { type: String },
-      ready:          { type: Boolean },
       value:          { type: String }
     };
   }
@@ -4894,26 +4807,10 @@ class AuroMenu extends r$4 {
         this.index = this.items.indexOf(evt.target);
         this.updateActiveOption(this.index);
       });
-
-      this.notifyReady();
     } else {
       // make sure to update all menuoption noCheckmark attributes when the menu is dynamically changed
       this.handleNoCheckmarkAttr();
     }
-  }
-
-  /**
-   * @private
-   * @returns {void} Marks the component as ready and sends event.
-   */
-  notifyReady() {
-    this.ready = true;
-
-    this.dispatchEvent(new CustomEvent('auroMenu-ready', {
-      bubbles: true,
-      cancelable: false,
-      composed: true,
-    }));
   }
 
   render() {

--- a/components/select/docs/api.md
+++ b/components/select/docs/api.md
@@ -25,7 +25,6 @@ The auro-select element is a wrapper for auro-dropdown and auro-menu to create a
 | Event                       | Type               | Description                                      |
 |-----------------------------|--------------------|--------------------------------------------------|
 | `auroFormElement-validated` |                    | Notifies that the `validity` and `errorMessage` values have changed. |
-| `auroSelect-ready`          | `CustomEvent<any>` | Notifies that the component has finished initializing. |
 | `auroSelect-valueSet`       | `CustomEvent<any>` | Notifies that the component has a new value set. |
 
 ## Slots

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -104,7 +104,6 @@ describe('auro-select', () => {
 
   it('make invalid selection programmatically results in error ui', async () => {
     const el = await presetValueFixture();
-    await waitUntil(() => el.ready);
 
     await expect(el.value).to.be.equal('price');
 
@@ -122,7 +121,6 @@ describe('auro-select', () => {
 
   it('reset selection value programmatically', async () => {
     const el = await presetValueFixture();
-    await waitUntil(() => el.ready);
 
     el.value = undefined;
 
@@ -149,8 +147,6 @@ describe('auro-select', () => {
 
   it('removing error attribute reruns validity even when value is undefined', async () => {
     const el = await errorFixture();
-
-    await waitUntil(() => el.ready);
 
     await expect(el.getAttribute('validity')).to.be.equal('customError');
 


### PR DESCRIPTION
# Alaska Airlines Pull Request

closed #72

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I have performed a self-review of my own update.**

## Summary by Sourcery

Refactor components to remove the 'ready' state and 'ready' events, simplifying the initialization process and updating documentation and tests accordingly.

Enhancements:
- Remove the 'ready' state and associated 'ready' events from components to simplify initialization logic.

Documentation:
- Update documentation to reflect the removal of 'ready' events and states across components.

Tests:
- Remove tests related to the 'ready' state and events from the test suite.