### PR TITLE
Add custom Stylelint rules

### DIFF
--- a/packages/config/src/custom-stylelint-rules/stylelint-sass-var-interpolation.mjs
+++ b/packages/config/src/custom-stylelint-rules/stylelint-sass-var-interpolation.mjs
@@ -1,3 +1,4 @@
+/* eslint-disable init-declarations */
 import stylelint from "stylelint";
 
 const ruleName = "custom/sass-var-interpolation-in-var-fallback";
@@ -7,8 +8,10 @@ const messages = stylelint.utils.ruleMessages(ruleName, {
 
 /**
  * Stylelint rule to enforce Sass variables in var() fallbacks are interpolated.
+ * @param {boolean} primaryOption - Whether the rule is enabled.
+ * @returns {Function} The rule function that processes CSS and reports violations.
  */
-const plugin = stylelint.createPlugin(ruleName, (primaryOption) => (root, result) => {
+const ruleFunction = (primaryOption) => (root, result) => {
   if (!primaryOption) {
     return;
   }
@@ -23,12 +26,10 @@ const plugin = stylelint.createPlugin(ruleName, (primaryOption) => (root, result
 
     // Find var() with a fallback argument containing a Sass variable
     const varWithFallbackRegex = /var\((?:[^,]+),\s*(?:[^)]+)\)/gu;
-    let matchArray = null;
+    let matchArray;
 
     while ((matchArray = varWithFallbackRegex.exec(value)) !== null) {
-      // Get the full match and extract the fallback part
       const [fullMatch] = matchArray;
-      // Extract the fallback (between the comma and the closing parenthesis)
       const commaIndex = fullMatch.indexOf(',');
       const closingParenIndex = fullMatch.lastIndexOf(')');
       const fallback = fullMatch.substring(commaIndex + 1, closingParenIndex).trim();
@@ -40,13 +41,17 @@ const plugin = stylelint.createPlugin(ruleName, (primaryOption) => (root, result
           node: decl,
           result,
           ruleName,
-          word: fallback
+          word: fallback,
         });
       }
     }
   });
-});
+};
+
+ruleFunction.ruleName = ruleName;
+ruleFunction.messages = messages;
+ruleFunction.meta = { fixable: false };
 
 // This export format is required for Stylelint plugins
-export default plugin;
+export default stylelint.createPlugin(ruleName, ruleFunction);
 export { ruleName, messages };

--- a/packages/config/src/custom-stylelint-rules/stylelint-unused-namespace.mjs
+++ b/packages/config/src/custom-stylelint-rules/stylelint-unused-namespace.mjs
@@ -1,0 +1,110 @@
+/**
+ * Stylelint rule to detect unused namespace declarations in SCSS files.
+ * This rule checks for @use statements with namespace aliases that are never referenced
+ * and reports them as lint errors.
+ * @module stylelint-unused-namespace
+ */
+
+import stylelint from "stylelint";
+
+const ruleName = 'custom/scss-unused-namespace';
+const messages = stylelint.utils.ruleMessages(ruleName, {
+  rejected: (namespace) => `Unused namespace "${namespace}" is declared but never used`
+});
+
+
+/**
+ * Main plugin rule function.
+ * @param {boolean} primaryOption - Whether the rule is enabled.
+ * @returns {Function} The rule function that processes CSS and reports violations.
+ */
+const ruleFunction = (primaryOption) => (root, result) => {
+
+  // Skip processing if rule is disabled
+  if (!primaryOption) {
+    return;
+  }
+
+  // Track namespace declarations and their usage
+  const namespaces = new Map();
+
+  // First pass: collect all @use declarations with namespaces
+  root.walkAtRules('use', (atRule) => {
+    // Extract namespace information from @use statements
+    const match = atRule.params.match(/['"](?<modulePath>[^'"]+)['"]\s+as\s+(?<namespace>[^;]+)/u);
+
+    if (match) {
+      const { modulePath, namespace } = match.groups;
+      const cleanNamespace = namespace.trim();
+
+      // Store namespace with its information
+      namespaces.set(cleanNamespace, {
+        modulePath,
+        node: atRule,
+        used: false,
+        line: atRule.source.start.line
+      });
+    }
+  });
+
+  // Skip if no namespaces found
+  if (namespaces.size === 0) {
+    return;
+  }
+
+  // Second pass: check for namespace usage in the file
+  root.walkDecls((decl) => {
+    // Check property and value for namespace references
+    const declString = decl.toString();
+
+    namespaces.forEach((info, namespace) => {
+      // Look for patterns like namespace.$var or namespace.function()
+      const namespacePattern = new RegExp(`${namespace}\\.\\S+`, 'u');
+
+      if (namespacePattern.test(declString)) {
+        info.used = true;
+      }
+    });
+  });
+
+  // Also check for namespaces in @include, @extend, etc.
+  root.walkAtRules((atRule) => {
+    // Skip @use rules as they were processed in the first pass
+    if (atRule.name === 'use') {
+      return;
+    }
+
+    const atRuleString = atRule.toString();
+
+    namespaces.forEach((info, namespace) => {
+      const namespacePattern = new RegExp(`${namespace}\\.\\S+`, 'u');
+
+      if (namespacePattern.test(atRuleString)) {
+        info.used = true;
+      }
+    });
+  });
+
+  // Report unused namespaces
+  namespaces.forEach((info, namespace) => {
+    if (!info.used) {
+      stylelint.utils.report({
+        message: messages.rejected(namespace),
+        node: info.node,
+        result,
+        ruleName,
+      });
+    }
+  });
+};
+
+ruleFunction.ruleName = ruleName;
+ruleFunction.messages = messages;
+ruleFunction.meta = { fixable: false };
+
+/**
+ * Export the plugin as the default export and also named exports for ruleName and messages.
+ */
+export default stylelint.createPlugin(ruleName, ruleFunction);
+export { ruleName, messages };
+

--- a/packages/config/src/stylelintrc.config.json
+++ b/packages/config/src/stylelintrc.config.json
@@ -2,10 +2,12 @@
   "extends": ["stylelint-config-recommended", "stylelint-config-idiomatic-order", "stylelint-config-standard-scss"],
   "plugins": [
     "stylelint-scss",
-    "./custom-stylelint-rules/stylelint-sass-var-interpolation.mjs"
+    "./custom-stylelint-rules/stylelint-sass-var-interpolation.mjs",
+    "./custom-stylelint-rules/stylelint-unused-namespace.mjs"
   ],
   "rules": {
     "custom/sass-var-interpolation-in-var-fallback": true,
+    "custom/scss-unused-namespace": true,
     "alpha-value-notation": "number",
     "at-rule-empty-line-before": [ "always", {
       "except": [


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Add a custom Stylelint rule and register it in the project's configuration to ensure Sass variables in CSS var() fallback values are properly interpolated.

New Features:
- Add a custom Stylelint plugin rule to enforce interpolation of Sass variables used in CSS var() fallbacks

Enhancements:
- Integrate the new custom rule into the shared Stylelint configuration