### PR TITLE
fix: not to steal focus when combobox.bib closes #723

### DIFF
--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -562,7 +562,11 @@ export class AuroCombobox extends AuroElement {
       this.dropdownOpen = ev.detail.expanded;
 
       // wait a frame in case the bib gets hide immediately after showing because there is no value
-      setTimeout(this.setInputFocus, 0);
+      setTimeout(() => {
+        if (document.activeElement === this) {
+          this.setInputFocus();
+        }
+      }, 0);
     });
 
     this.dropdown.addEventListener('auroDropdown-triggerClick', () => {


### PR DESCRIPTION
# Alaska Airlines Pull Request

when dropdown is toggled, check if focus is moved to another element before calling trigger.focus()

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Bug Fixes:
- Only refocus the combobox input if the component is still the active element after toggling the dropdown