### PR TITLE
fix: hide input's clear when it's not holding focus/hover

### DIFF
--- a/components/input/src/styles/style.scss
+++ b/components/input/src/styles/style.scss
@@ -58,6 +58,13 @@ input {
   }
 }
 
+.wrapper:not(:focus-within):not(:hover) { // stylelint-disable selector-not-notation
+  .notificationBtn.passwordBtn,
+  .notification.clear {
+    display: none;
+  }
+}
+
 .notification {
   display: flex;
   align-items: center;


### PR DESCRIPTION
# Alaska Airlines Pull Request

This PR is to hide x button when input does not have focus or on non-hover state.

Did not apply `.util_displayVisuallyHidden` programatically. Because, to do that, each auro-input needs to listen to `mouseenter`, `mouseleave` event which is not so great for the performance. 

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Bug Fixes:
- Hide clear icon when input wrapper is not focused or hovered