### PR TITLE
fix: center align snowflake combobox's helptext #957

### DIFF
--- a/components/combobox/src/styles/snowflake/style.scss
+++ b/components/combobox/src/styles/snowflake/style.scss
@@ -6,4 +6,8 @@
       display: none;
     }
   }
+
+  &::part(helpText) {
+    text-align: center;
+  }
 }


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Bug Fixes:
- Center-align the help text for the Snowflake combobox