### PR TITLE
fix: chromium-related input focus in combobox

### DIFF
--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -643,6 +643,29 @@ export class AuroCombobox extends AuroElement {
   }
 
   /**
+   * Forces focus to the internal input element and positions the cursor at the end of the text.
+   * This is used when clicking anywhere within the Combobox to ensure the input receives focus
+   * and the cursor is positioned at the end for better user experience.
+   * @private
+   * @returns {void}
+   */
+  forceFocusToInputEnd() {
+    // Set up input ref
+    let inputElement = null;
+
+    if (this.input.shadowRoot) {
+      inputElement = this.input.shadowRoot.querySelector('input');
+    }
+
+    if (inputElement) {
+      // Force focus and set cursor position to end of text to ensure visibility
+      inputElement.focus();
+      const textLength = inputElement.value ? inputElement.value.length : 0;
+      inputElement.setSelectionRange(textLength, textLength);
+    }
+  }
+
+  /**
    * Binds all behavior needed to the dropdown after rendering.
    * @private
    * @returns {void}
@@ -670,6 +693,9 @@ export class AuroCombobox extends AuroElement {
 
     this.dropdown.addEventListener('auroDropdown-triggerClick', () => {
       this.showBib();
+
+      // Fixes Chromium-specific issue where clicking outside input but within Combobox doesn't return focus
+      this.forceFocusToInputEnd();
     });
 
     // setting up bibtemplate


### PR DESCRIPTION
# Alaska Airlines Pull Request

When clicking into an `input` in a Chromium-based browser such as Chrome or Edge, and then clicking outside of the `input` (but within the Combobox), `focus` is not returned to the `input`

**Before:**

https://github.com/user-attachments/assets/704b5421-150a-4742-8c8a-b7b67d1b0b9b

After:

https://github.com/user-attachments/assets/95381e8a-8be8-4d02-be2c-41d1e5108345

## Testing

Tested in:

- Chrome (Mac)
- Chrome (Windows 11)
- Edge (Mac)
- Edge (Windows 11)
- Safari (Mac)
- Firefox (Mac)

## Resources

Related to https://dev.azure.com/itsals/E_Retain_Content/_workitems/edit/1340162

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Ensure the combobox input receives focus and the cursor is placed at the end of its text when clicking anywhere inside the component to resolve Chromium focus inconsistencies.

Bug Fixes:
- Fix Chromium-specific issue where clicking within the combobox but outside the input didn’t return focus to the input

Enhancements:
- Add a private forceFocusToInputEnd method to focus the internal input and position the cursor at the end

## Summary by Sourcery

Fix input focus regressions in Chromium-based browsers by ensuring the combobox input regains focus and positions the cursor at the end when clicking anywhere inside the component

Bug Fixes:
- Restore focus to the input when clicking within the combobox but outside the input in Chromium browsers

Enhancements:
- Add forceFocusToInputEnd private method to focus the internal input and set the cursor position to the end