### PR TITLE
Improve aria-invalid attribute handling for error and validity

### DIFF
--- a/components/radio/src/auro-radio-group.js
+++ b/components/radio/src/auro-radio-group.js
@@ -249,10 +249,14 @@ export class AuroRadioGroup extends LitElement {
 
     if (changedProperties.has('validity')) {
       if (this.validity && this.validity !== 'valid') {
+        this.setAttribute('aria-invalid', 'true');
+
         this.items.forEach((el) => {
           el.setAttribute('error', true);
         });
       } else {
+        this.removeAttribute('aria-invalid');
+
         this.items.forEach((el) => {
           el.removeAttribute('error');
         });

--- a/components/radio/src/auro-radio.js
+++ b/components/radio/src/auro-radio.js
@@ -204,16 +204,6 @@ export class AuroRadio extends LitElement {
   }
 
   updated(changedProperties) {
-    if (changedProperties.has('error') || changedProperties.has('validity')) {
-      if (this.error) {
-        this.setAttribute('aria-invalid', 'true');
-      } else if (this.validity === 'valid') {
-        this.setAttribute('aria-invalid', 'false');
-      } else {
-        this.removeAttribute('aria-invalid');
-      }
-    }
-
     if (changedProperties.has('required')) {
       this.setAttribute('aria-required', this.isRequired(this.required));
     }


### PR DESCRIPTION
# Alaska Airlines Pull Request

This PR addresses an issue where `Invalid user entry: true` was always set.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Enhancements:
- Refine aria-invalid handling to set to true when there's an error, false when valid, and remove the attribute otherwise for better accessibility semantics.