### PR TITLE
Prevent menu from overriding user input on keydown in combobox #1129

### DIFF
--- a/components/combobox/apiExamples/dynamicMenu.html
+++ b/components/combobox/apiExamples/dynamicMenu.html
@@ -19,8 +19,7 @@
   -->
   <auro-menu id="initMenu"></auro-menu>
 </auro-combobox>
-
-
+<br>
 <auro-combobox
   id="dynamicMenuExampleTwo"
   value="GER"
@@ -40,7 +39,13 @@
   -->
   <auro-menu id="initMenuTwo"></auro-menu>
 </auro-combobox>
-
+<br>
 <auro-button id="dynamicMenuSwapButton">
   Swap Values
 </auro-button>
+
+<auro-button id="dynamicMenuPersistButton">
+  Toggle Persist Input
+</auro-button>
+
+

--- a/components/combobox/apiExamples/dynamicMenu.js
+++ b/components/combobox/apiExamples/dynamicMenu.js
@@ -37,6 +37,14 @@ export async function dynamicMenuExample() {
     swapValues();
   });
 
+  document.querySelector('#dynamicMenuPersistButton').addEventListener('click', () => {
+    const elOne = document.querySelector('#dynamicMenuExample');
+    const elTwo = document.querySelector('#dynamicMenuExampleTwo');
+
+    elOne.persistInput = !elOne.persistInput;
+    elTwo.persistInput = !elTwo.persistInput;
+  });
+
   // Generates HTML for menu and submenus using country & city data from an external API
   function generateHtml(data, selector) {
     const initialMenu = document.querySelector(selector);
@@ -94,13 +102,13 @@ export async function dynamicMenuExample() {
 
   // TODO: Need to refactor this to to not console a console error
   const dynamicDataTwo = new DynamicData();
-  const dynamicMenuExampleElTwo = document.querySelector('#dynamicMenuExample');
+  const dynamicMenuExampleElTwo = document.querySelector('#dynamicMenuExampleTwo');
   const dropdownElTwo = dynamicMenuExampleElTwo.shadowRoot.querySelector(dynamicMenuExampleElTwo.dropdownTag._$litStatic$);
   const inputElTwo = dropdownElTwo.querySelector(dynamicMenuExampleElTwo.inputTag._$litStatic$);
 
   inputElTwo.addEventListener('input', () => {
     let data = dynamicDataTwo.getData();
-    data = dynamicDataTwo.filterData(data, inputEl.value);
+    data = dynamicDataTwo.filterData(data, inputElTwo.value);
 
     generateHtml(data, '#initMenuTwo');
   });

--- a/components/menu/src/auro-menu.js
+++ b/components/menu/src/auro-menu.js
@@ -682,9 +682,8 @@ export class AuroMenu extends AuroElement {
   /**
    * Handles slot change events.
    * @private
-   * @param {Event} evt - Event object from the browser.
    */
-  handleSlotChange(evt) {
+  handleSlotChange() {
     if (this.parentElement && this.parentElement.closest('auro-menu, [auro-menu]')) {
       this.rootMenu = false;
     }
@@ -698,15 +697,6 @@ export class AuroMenu extends AuroElement {
           true
         ]
       ]));
-    }
-
-    if (this.value) {
-      this.items.forEach((opt) => {
-        if (opt.value === this.value || (this.multiSelect && this.formattedValue.includes(opt.value))) {
-          this.handleSelectState(opt);
-          this.notifySelectionChange(evt.type);
-        }
-      });
     }
   }
 


### PR DESCRIPTION
# Alaska Airlines Pull Request

This PR removes a portion of code in the menu that was triggering a change on the menu and then forcing the menu to apply the selected value on the combobox input

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Prevent the menu from forcing selected values into the combobox input on slot changes by removing the auto-select logic in AuroMenu; fix and enhance the dynamicMenu combobox example by correcting element references, adjusting filter behavior, and adding a button to toggle input persistence.

New Features:
- Add 'Toggle Persist Input' button to the dynamicMenu example for switching the combobox's persistInput property

Bug Fixes:
- Fix dynamicMenu example to target the correct combobox element and input when filtering
- Remove auto-selection code in AuroMenu.handleSlotChange to stop menu interactions from overriding manual user input

Enhancements:
- Simplify AuroMenu.handleSlotChange by removing unused event parameter from its signature

Documentation:
- Update dynamicMenu HTML example with new button and line breaks