### PR TITLE
feat: #1132 remove styles that hide the "clear" button for the input in the fullscreen bib for combobox

### DIFF
--- a/components/combobox/src/styles/style.scss
+++ b/components/combobox/src/styles/style.scss
@@ -21,10 +21,6 @@
     &::part(accent-left) {
       display: none;
     }
-
-    &::part(accent-right) {
-      display: none;
-    }
   }
 }
 


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Enhancements:
- Allow the clear (accent-right) button to display in fullscreen combobox by deleting the display:none style