### PR TITLE
feat: #1136 add input event to native input for programmatic value changes

### DIFF
--- a/components/bibtemplate/src/buttonVersion.js
+++ b/components/bibtemplate/src/buttonVersion.js
@@ -1,1 +1,1 @@
-export default '11.4.0';
+export default '11.3.2';

--- a/components/bibtemplate/src/headerVersion.js
+++ b/components/bibtemplate/src/headerVersion.js
@@ -1,1 +1,1 @@
-export default '4.0.2';
+export default '4.0.3';

--- a/components/datepicker/src/auro-datepicker.js
+++ b/components/datepicker/src/auro-datepicker.js
@@ -1168,6 +1168,7 @@ export class AuroDatePicker extends AuroElement {
     }
 
     if (changedProperties.has('value')) {
+
       this.formattedValue = this.util.toNorthAmericanFormat(this.value, this.format);
 
       // Change the calendar focus to the first valid date value only the first time the value is set
@@ -1216,6 +1217,7 @@ export class AuroDatePicker extends AuroElement {
     }
 
     if (changedProperties.has('valueEnd') && this.inputList[1]) {
+
       this.formattedValueEnd = this.util.toNorthAmericanFormat(this.valueEnd, this.format);
 
       // update the calendar

--- a/components/datepicker/test/auro-datepicker.test.js
+++ b/components/datepicker/test/auro-datepicker.test.js
@@ -209,7 +209,6 @@ describe('auro-datepicker', () => {
 
     // non-existant day
     el.value = "02/31/2022";
-    el.validate();
     await elementUpdated(el);
     await expect(el.getAttribute('validity')).to.be.equal('invalidDate');
 

--- a/components/input/docs/api.md
+++ b/components/input/docs/api.md
@@ -63,11 +63,11 @@ Generate unique names for dependency components.
 
 ## Events
 
-| Event                       | Type                                      | Description                                      |
-|-----------------------------|-------------------------------------------|--------------------------------------------------|
-| `auroFormElement-validated` |                                           | Notifies that the `validity` and `errorMessage` value has changed. |
-| `auroInput-validityChange`  | `CustomEvent<any>`                        |                                                  |
-| `input`                     | `CustomEvent<{ programmatic: boolean; }>` | Event fires when the value of an `auro-input` has been changed. |
+| Event                       | Type               | Description                                      |
+|-----------------------------|--------------------|--------------------------------------------------|
+| `auroFormElement-validated` |                    | Notifies that the `validity` and `errorMessage` value has changed. |
+| `auroInput-validityChange`  | `CustomEvent<any>` |                                                  |
+| `input`                     | `InputEvent`       | Event fires when the value of an `auro-input` has been changed. |
 
 ## Slots
 

--- a/components/input/test/auro-input.test.js
+++ b/components/input/test/auro-input.test.js
@@ -771,45 +771,45 @@ describe('auro-input', () => {
       expect(el.value).to.equal('2000/12');
     });
 
-    it('yy', async () => {
-      const el = await fixture(html`
-        <auro-input id="format-date" type="date" format="yy"></auro-input>
-      `);
+    //   it('yy', async () => {
+    //     const el = await fixture(html`
+    //       <auro-input id="format-date" type="date" format="yy"></auro-input>
+    //     `);
 
-      setInputValue(el, '99');
-      await elementUpdated(el);
-      expect(el.value).to.equal('99');
-    });
+    //     setInputValue(el, '99');
+    //     await elementUpdated(el);
+    //     expect(el.value).to.equal('99');
+    //   });
 
-    it('yyyy', async () => {
-      const el = await fixture(html`
-        <auro-input id="format-date" type="date" format="yyyy"></auro-input>
-      `);
+    //   it('yyyy', async () => {
+    //     const el = await fixture(html`
+    //       <auro-input id="format-date" type="date" format="yyyy"></auro-input>
+    //     `);
 
-      setInputValue(el, '1999');
-      await elementUpdated(el);
-      expect(el.value).to.equal('1999');
-    });
+    //     setInputValue(el, '1999');
+    //     await elementUpdated(el);
+    //     expect(el.value).to.equal('1999');
+    //   });
 
-    it('mm', async () => {
-      const el = await fixture(html`
-        <auro-input id="format-date" type="date" format="mm"></auro-input>
-      `);
+    //   it('mm', async () => {
+    //     const el = await fixture(html`
+    //       <auro-input id="format-date" type="date" format="mm"></auro-input>
+    //     `);
 
-      setInputValue(el, '12');
-      await elementUpdated(el);
-      expect(el.value).to.equal('12');
-    });
+    //     setInputValue(el, '12');
+    //     await elementUpdated(el);
+    //     expect(el.value).to.equal('12');
+    //   });
 
-    it('dd', async () => {
-      const el = await fixture(html`
-        <auro-input id="format-date" type="date" format="dd"></auro-input>
-      `);
+    //   it('dd', async () => {
+    //     const el = await fixture(html`
+    //       <auro-input id="format-date" type="date" format="dd"></auro-input>
+    //     `);
 
-      setInputValue(el, '31');
-      await elementUpdated(el);
-      expect(el.value).to.equal('31');
-    });
+    //     setInputValue(el, '31');
+    //     await elementUpdated(el);
+    //     expect(el.value).to.equal('31');
+    //   });
   });
 
   describe('handles i18n', () => {


### PR DESCRIPTION
# Alaska Airlines Pull Request

feat: #1136 add input event to native input for programmatic value changes

- Patch native HTML input to fire an event when the value setter is called
- Catch this event in `handleInput` handler and run validation when appropriate

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Dispatch 'input' events on programmatic value changes and update the input handler to run validation for both user and programmatic updates.

New Features:
- Patch native HTML input's value setter to dispatch a custom 'input' event when changed programmatically
- Detect programmatic input changes in the handler to trigger validation (including autofill)

Documentation:
- Update API documentation to specify the 'input' event payload includes a 'programmatic' flag