### PR TITLE
fix: pass `ariaLabel.clear` slot into datepicker's input #1165

### DIFF
--- a/components/datepicker/src/auro-datepicker.js
+++ b/components/datepicker/src/auro-datepicker.js
@@ -1626,6 +1626,7 @@ export class AuroDatePicker extends AuroElement {
             `
         : undefined
       }
+          <span slot="ariaLabel.clear">${i18n(this.lang, 'clearInput')}</span>
           <span slot="label"><slot name="fromLabel"></slot></span>
         </${this.inputTag}>
       </div>
@@ -1667,6 +1668,7 @@ export class AuroDatePicker extends AuroElement {
             `
           : undefined
         }
+            <span slot="ariaLabel.clear">${i18n(this.lang, 'clearInput')}</span>
             <span slot="label"><slot name="toLabel"></slot></span>
           </${this.inputTag}>
         </div>


### PR DESCRIPTION
# Alaska Airlines Pull Request

pass ariaLabel.clearn to datepicker's input on classic layout

closes #1165 

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Add ariaLabel.clear slot to classic layout datepicker inputs to improve accessibility for the clear action.

Bug Fixes:
- Include ariaLabel.clear slot for clear button on the start date input in classic layout
- Include ariaLabel.clear slot for clear button on the end date input in classic layout