### PR TITLE
fix: update radio-group to validate radios with non-string value properly #1168

### DIFF
--- a/components/radio/src/auro-radio-group.js
+++ b/components/radio/src/auro-radio-group.js
@@ -200,7 +200,8 @@ export class AuroRadioGroup extends LitElement {
    * @returns {void}
    */
   handleSelection(event) {
-    if (event.target.value) {
+    // specifically check null and undefined in case if the value is false or 0
+    if (event.target.value !== null && event.target.value !== undefined) {
       this.value = event.target.value;
     } else {
       this.value = '';

--- a/packages/form-validation/src/validation.js
+++ b/packages/form-validation/src/validation.js
@@ -269,6 +269,14 @@ export default class AuroFormValidation {
       if (typeof elem.value === "string") {
         hasValue = elem.value && elem.value.length > 0;
       }
+      
+      if (typeof elem.value === "boolean") {
+        hasValue = elem.value || elem.value === false;
+      }
+
+      if (typeof elem.value === "number") {
+        hasValue = !isNaN(elem.value) && elem.value !== null;
+      }
 
       // Check array value types for having a value
       if (Array.isArray(elem.value)) {


### PR DESCRIPTION
# Alaska Airlines Pull Request

## Problem
Although it's specified that `value` to be String, in svelte the value can set as any type.
When customer sets a radio to have `false` or `0`, radio-group returns valueMissing validity upon that radio's selection.

### Solution
- update `validate()` to handle `number` and `boolean` type value.
- update radio-group to take any type of value on a radio's selection event.

Closes #1168

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Update form validation and radio-group components to support non-string values, preventing incorrect `valueMissing` errors when a radio input has boolean or numeric values.

Bug Fixes:
- Extend `validate()` to correctly detect boolean and numeric values as having a value
- Allow radio-group selection logic to accept `0`, `false`, or other non-string values without treating them as missing