### PR TITLE
fix: properly set value on custom registered select #1216

### DIFF
--- a/components/menu/src/auro-menuoption.js
+++ b/components/menu/src/auro-menuoption.js
@@ -112,10 +112,15 @@ export class AuroMenuOption extends AuroElement {
     AuroLibraryRuntimeUtils.prototype.registerComponent(name, AuroMenuOption);
   }
 
-  firstUpdated() {
-    // Add the tag name as an attribute if it is different than the component name
-    this.runtimeUtils.handleComponentTagRename(this, 'auro-menuoption');
+  connectedCallback() {
+    super.connectedCallback();
 
+    // Add the tag name as an attribute if it is different than the component name
+    // Add this step soon as this node gets attached to the DOM to avoid racing condition with menu's value setting logic.
+    this.runtimeUtils.handleComponentTagRename(this, 'auro-menuoption');
+  }
+
+  firstUpdated() {
     if (!this.hasAttribute('size')) {
       this.size = this.parentElement.getAttribute('size') || 'sm';
     }

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -681,6 +681,7 @@ export class AuroSelect extends AuroElement {
     }
 
     this.updateMenuShapeSize();
+    this.updateMenuValue(this.value);
 
     if (this.multiSelect) {
       this.menu.multiSelect = this.multiSelect;


### PR DESCRIPTION
# Alaska Airlines Pull Request

When auro-select gets custom registered and has `value` attribute set, custom registered auro-menu was not able to properly set `value` because the timing issue when custom registered auro-menuoption gets the tag.
There were 2 issues.

### 1st issue
1. auro-select gets generated
2. auro-select.firstUpdated gets called
3. auro-select.updated gets called with `value` changed
4. menu was not initialized yet
5. initMenu gets retried after {xx}ms
6. menu.value does not get set after menu gets initialized
#### Solution: call `this.updateMenuValue` after initializing menu

### 2nd issue
1. After the 1st issue gets fixed
2. auro-menu.updated gets called with `value` changed
3. auro-menu tries to find the matching value from `auro-menu.items`
4. but `auro-menu.items` is still empty because none of `menuoption` has `auro-menuoption` tag attached yet. (auro-menuoption tag gets attached on auro-menuoption.firstUpdated call - which is not called yet.
#### Solution: attach `auro-menuoption` tag on `auro-menuoption.connectedCallback` call


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Fix component initialization to properly set values on custom registered selects and avoid race conditions

Bug Fixes:
- Move tag rename logic in AuroMenuOption to connectedCallback to prevent race conditions with value setting
- Invoke updateMenuValue in AuroSelect after updating menu size to correctly set the select's initial value