### PR TITLE
ci: add `--ignore-scripts` flag to npx commands in action.yml and pull-request.yml

### DIFF
--- a/.github/actions/check-commits/action.yml
+++ b/.github/actions/check-commits/action.yml
@@ -26,7 +26,7 @@ runs:
         git --version
       shell: bash
     - name: Auro Check Commits
-      run: npx --package=@aurodesignsystem/auro-cli -- auro cc -l -d
+      run: npx  --ignore-scripts  --package=@aurodesignsystem/auro-cli -- auro cc -l -d
       shell: bash
       env:
           GITHUB_TOKEN: ${{ inputs.github-token }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -69,7 +69,7 @@ jobs:
               ./node_modules
             key: build-22-${{ github.run_id }}
         - name: Generate PR release version
-          run: npx --package=@aurodesignsystem/auro-cli -- auro pr-release -p ${{ github.event.pull_request.number }}
+          run: npx  --ignore-scripts  --package=@aurodesignsystem/auro-cli -- auro pr-release -p ${{ github.event.pull_request.number }}
         - name: Read package.json
           id: package
           uses: actions/github-script@v6


### PR DESCRIPTION
# Alaska Airlines Pull Request

- rollup package's postinstall script expecting patch-package to be available

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Add --ignore-scripts flag to npx invocations in CI to skip package postinstall scripts and prevent dependency errors.

Bug Fixes:
- Prevent rollup postinstall script from causing CI failures by skipping scripts during npx execution

CI:
- Add --ignore-scripts flag to the npx command in the check-commits GitHub action
- Add --ignore-scripts flag to the npx command in the pull-request workflow