### PR TITLE
fix: wait for child's attr to update before validate on `error` update #1191

### DIFF
--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -1103,7 +1103,7 @@ export class AuroCombobox extends AuroElement {
     this.validation.validate(this, force);
   }
 
-  updated(changedProperties) {
+  async updated(changedProperties) {
     // After the component is ready, send direct value changes to auro-menu.
     if (changedProperties.has('value')) {
       if (this.value && this.value.length > 0) {
@@ -1161,8 +1161,8 @@ export class AuroCombobox extends AuroElement {
     }
 
     if (changedProperties.has('error')) {
-      this.input.setAttribute('error', this.getAttribute('error'));
-      this.validate();
+      await this.input.setAttribute('error', this.getAttribute('error'));
+      this.validate(true);
     }
 
     if (changedProperties.has('shape') && this.menu) {

--- a/components/datepicker/src/auro-datepicker.js
+++ b/components/datepicker/src/auro-datepicker.js
@@ -1163,7 +1163,7 @@ export class AuroDatePicker extends AuroElement {
     return this.validity !== undefined && this.validity !== 'valid';
   }
 
-  updated(changedProperties) {
+  async updated(changedProperties) {
     if (changedProperties.has('format')) {
       this.monthFirst = this.format.indexOf('mm') < this.format.indexOf('yyyy');
     }
@@ -1294,10 +1294,10 @@ export class AuroDatePicker extends AuroElement {
 
       if (this.hasAttribute('error')) {
         // Set the error attribute on the last input
-        lastInput.setAttribute('error', this.getAttribute('error'));
+        await lastInput.setAttribute('error', this.getAttribute('error'));
       } else {
         // Remove the error attribute on the last input
-        lastInput.removeAttribute('error');
+        await lastInput.removeAttribute('error');
       }
 
       // Validate the last input


### PR DESCRIPTION
# Alaska Airlines Pull Request
### Problem
When `error` is updated on combobox/datepicker, `validate` gets called before finalizing `error` attribute update on a child (input element), which leads validator to think input still has `validity="customError"` 
### Solution
wait for child's attribute update before calling `validate`

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Ensure combobox and datepicker validation runs only after child input error attributes have been fully updated.

Bug Fixes:
- Fix race condition where combobox validation could run before the input element’s error attribute was updated.
- Fix datepicker error handling so validation occurs after the final input’s error attribute is reliably set or cleared.