### PR TITLE
fix: correct casing on `noCheckmark` so that the property is correctly snyc'd

### DIFF
--- a/components/menu/src/auro-menuoption.js
+++ b/components/menu/src/auro-menuoption.js
@@ -81,7 +81,7 @@ export class AuroMenuOption extends AuroElement {
     this.iconTag = versioning.generateTag('auro-formkit-menuoption-icon', iconVersion, AuroIcon);
 
     this.selected = false;
-    this.nocheckmark = false;
+    this.noCheckmark = false;
     this.disabled = false;
 
     /**
@@ -122,7 +122,7 @@ export class AuroMenuOption extends AuroElement {
         type: String,
         state: true
       },
-      nocheckmark: {
+      noCheckmark: {
         type: Boolean,
         reflect: true
       },
@@ -457,7 +457,7 @@ export class AuroMenuOption extends AuroElement {
 
     return html`
       <div class="${classes}">
-        ${this.selected && !this.nocheckmark
+        ${this.selected && !this.noCheckmark
         ? this.generateIconHtml(checkmarkIcon.svg)
         : undefined}
         <slot></slot>


### PR DESCRIPTION
# Alaska Airlines Pull Request

Correct casing on `noCheckmark` so that the property is correctly snyc'd

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Bug Fixes:
- Correct the casing of the `noCheckmark` boolean property in `AuroMenuOption` so checkmark rendering responds to it as intended.