### PR TITLE
Ensure combobox displays the label of the selected menu option and not the value

### DIFF
--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -575,17 +575,19 @@ export class AuroCombobox extends AuroElement {
     if (this.menu) {
       this.menu.matchWord = this.input.value;
     }
-    this.updateTriggerTextDisplay();
+    const label = this.menu.currentLabel;
+    this.updateTriggerTextDisplay(label || this.value);
   }
 
   /**
    * Update displayValue or input.value, it's called when making a selection.
+   * @param {string} label - The label of the selected option.
    * @private
    */
-  updateTriggerTextDisplay() {
+  updateTriggerTextDisplay(label) {
     // update the input content if persistInput is false
     if (!this.persistInput) {
-      this.input.value = this.value;
+      this.input.value = label || this.value;
     }
 
     // update the displayValue in the trigger if displayValue slot content is present
@@ -811,7 +813,7 @@ export class AuroCombobox extends AuroElement {
       this.value = event.detail.stringValue;
 
       // Update display
-      this.updateTriggerTextDisplay();
+      this.updateTriggerTextDisplay(event.detail.label || event.detail.value);
 
       // Update match word for filtering
       if (this.menu.matchWord !== this.input.value) {

--- a/components/menu/docs/api.md
+++ b/components/menu/docs/api.md
@@ -7,6 +7,7 @@ The auro-menu element provides users a way to select from a list of options.
 | Property                   | Attribute                  | Modifiers | Type                              | Default     | Description                                      |
 |----------------------------|----------------------------|-----------|-----------------------------------|-------------|--------------------------------------------------|
 | `allowDeselect`            | `allowDeselect`            |           | `boolean`                         | false       | Allows deselecting an already selected option when clicked again in single-select mode. |
+| `currentLabel`             |                            | readonly  | `string`                          |             |                                                  |
 | `disabled`                 | `disabled`                 |           | `boolean`                         |             | When true, the entire menu and all options are disabled; |
 | `hasLoadingPlaceholder`    |                            |           | `boolean`                         |             | Indicates whether the menu has a loadingIcon or loadingText to render when in a loading state. |
 | `index`                    |                            |           | `number`                          |             |                                                  |

--- a/components/menu/src/auro-menu.context.js
+++ b/components/menu/src/auro-menu.context.js
@@ -34,6 +34,15 @@ export class MenuService {
   }
 
   /**
+   * Gets the label(s) of the currently selected option(s).
+   * @returns {string}
+   */
+  get currentLabel() {
+    const labels = (this.selectedOptions || []).map(option => option.textContent);
+    return this.multiSelect ? labels.join(", ") : labels[0] || '';
+  }
+
+  /**
    * Gets the string representation of the current value(s).
    * For multi-select, this is a JSON stringified array.
    * @returns {string|undefined}
@@ -464,7 +473,8 @@ export class MenuService {
       value: this.currentValue,
       stringValue: this.stringValue,
       keys: this.currentKeys,
-      options: this.selectedOptions
+      options: this.selectedOptions,
+      label: this.currentLabel
     }
 
     // If only one option is selected, include its index

--- a/components/menu/src/auro-menu.js
+++ b/components/menu/src/auro-menu.js
@@ -201,6 +201,14 @@ export class AuroMenu extends AuroElement {
 
   /**
    * @readonly
+   * @returns {string} - Returns the label of the currently selected option(s).
+   */
+  get currentLabel() {
+    return this.menuService.currentLabel;
+  };
+
+  /**
+   * @readonly
    * @returns {Array<HTMLElement>} - Returns the array of available menu options.
    * @deprecated use `options` property instead.
    */


### PR DESCRIPTION
# Alaska Airlines Pull Request

Ensure combobox displays the label of the selected menu option and not the value

- Add getter for currentLabel to menu context
- Add label to event value for `auroMenu-selectOption in menu context
- Consume label from combobox ensuring value is returned via value property but label is displayed to user

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Ensure combobox displays the selected option’s label to users while preserving its underlying value.

New Features:
- Expose the current selected option label via a new currentLabel getter on the menu context.
- Include the selected option label in the auroMenu-selectOption event payload.

Bug Fixes:
- Update combobox to display the selected option label in the input while still using the option value for form submission and filtering.