### PR TITLE
Add combobox framework tests for React and Svelte

### DIFF
--- a/apps/react-framework/src/App.tsx
+++ b/apps/react-framework/src/App.tsx
@@ -2,6 +2,7 @@ import { Router, Route } from './router';
 import Home from './pages/Home';
 import SelectRemount from './pages/SelectRemount';
 import SelectRemountMultiselect from './pages/SelectRemountMultiselect';
+import ComboboxRemount from './pages/ComboboxRemount';
 
 export default function App() {
   return (
@@ -9,6 +10,7 @@ export default function App() {
       <Route path="/" component={Home} />
       <Route path="/select-remount" component={SelectRemount} />
       <Route path="/select-remount-multiselect" component={SelectRemountMultiselect} />
+      <Route path="/combobox-remount" component={ComboboxRemount} />
     </Router>
   );
 }

--- a/apps/react-framework/src/main.tsx
+++ b/apps/react-framework/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import '@aurodesignsystem/auro-formkit/auro-select'
+import '@aurodesignsystem/auro-formkit/auro-combobox'
 import '@aurodesignsystem/auro-formkit/auro-menu'
 import './index.css'
 import App from './App.tsx'

--- a/apps/react-framework/src/pages/ComboboxRemount.tsx
+++ b/apps/react-framework/src/pages/ComboboxRemount.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      'auro-combobox': React.HTMLAttributes<HTMLElement> & { value?: string; behavior?: string };
+      'auro-menu': React.HTMLAttributes<HTMLElement>;
+      'auro-menuoption': React.HTMLAttributes<HTMLElement> & { value?: string };
+    }
+  }
+}
+
+const OPTIONS: [string, string][] = [
+  ['Apples', 'Apples'],
+  ['Oranges', 'Oranges'],
+  ['Peaches', 'Peaches'],
+  ['Grapes', 'Grapes'],
+];
+
+const INITIAL_VALUE = 'Apples';
+
+function ComboboxWrapper() {
+  return (
+    <auro-combobox behavior="filter" value={INITIAL_VALUE}>
+      <auro-menu>
+        {OPTIONS.map(([value, label]) => (
+          <auro-menuoption key={value} value={value}>{label}</auro-menuoption>
+        ))}
+      </auro-menu>
+    </auro-combobox>
+  );
+}
+
+export default function ComboboxRemount() {
+  const [show, setShow] = useState(true);
+
+  function setInvalidValue() {
+    const el = document.querySelector('auro-combobox') as any;
+    if (el) el.value = 'invalid-option';
+  }
+
+  return (
+    <div>
+      <button id="toggle" onClick={() => setShow((s) => !s)}>
+        {show ? 'Hide' : 'Show'} Combobox
+      </button>
+      <button id="set-invalid" onClick={setInvalidValue}>Set Invalid Value</button>
+      {show && <ComboboxWrapper />}
+    </div>
+  );
+}

--- a/apps/react-framework/src/pages/Home.tsx
+++ b/apps/react-framework/src/pages/Home.tsx
@@ -3,6 +3,7 @@ import { Link } from '../router';
 const SUITES: { label: string; path: string }[] = [
   { label: 'auro-select: remount', path: '/select-remount' },
   { label: 'auro-select: remount (multiselect)', path: '/select-remount-multiselect' },
+  { label: 'auro-combobox: remount', path: '/combobox-remount' },
 ];
 
 export default function Home() {

--- a/apps/react-framework/tests/combobox-remount.spec.ts
+++ b/apps/react-framework/tests/combobox-remount.spec.ts
@@ -1,0 +1,3 @@
+import { comboboxRemountSuite } from '../../shared/combobox-remount.suite';
+
+comboboxRemountSuite('React');

--- a/apps/shared/combobox-remount.suite.ts
+++ b/apps/shared/combobox-remount.suite.ts
@@ -1,0 +1,106 @@
+import { test, expect, type Page } from '@playwright/test';
+
+/** Poll until auro-combobox.value matches the expected value or we time out. */
+async function waitForComboboxValue(page: Page, expected: string, timeout = 3000) {
+  await page.waitForFunction(
+    ([selector, val]) =>
+      (document.querySelector(selector as string) as any)?.value === val,
+    ['auro-combobox', expected],
+    { timeout },
+  );
+}
+
+function assertValue(page: Page, expectedValue: string) {
+  return page.locator('auro-combobox').evaluate((el: any, val: string) => {
+    return { value: el.value, match: el.value === val };
+  }, expectedValue);
+}
+
+interface SuiteOptions {
+  route: string;
+  initialValue: string;
+}
+
+export function comboboxRemountSuite(framework: string, options?: SuiteOptions) {
+  const { route, initialValue } = options ?? {
+    route: '/combobox-remount',
+    initialValue: 'Apples',
+  };
+
+  const label = `auro-combobox in ${framework}`;
+
+  test.describe(label, () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto(route);
+      await page.waitForFunction(() => customElements.get('auro-combobox') !== undefined, { timeout: 10_000 });
+    });
+
+    test('initial value is set on first render', async ({ page }) => {
+      await waitForComboboxValue(page, initialValue);
+      const { value } = await assertValue(page, initialValue);
+      expect(value).toBe(initialValue);
+    });
+
+    test('value is restored after DOM remount', async ({ page }) => {
+      await waitForComboboxValue(page, initialValue);
+
+      // Unmount
+      await page.locator('#toggle').click();
+      await page.waitForSelector('auro-combobox', { state: 'detached' });
+
+      // Remount
+      await page.locator('#toggle').click();
+      await page.waitForSelector('auro-combobox', { state: 'attached' });
+
+      await waitForComboboxValue(page, initialValue);
+      const { value } = await assertValue(page, initialValue);
+      expect(value).toBe(initialValue);
+    });
+
+    test('setting an invalid value clears the selection', async ({ page }) => {
+      await waitForComboboxValue(page, initialValue);
+
+      await page.locator('#set-invalid').click();
+
+      // Wait for value to be cleared
+      await page.waitForFunction(
+        () => (document.querySelector('auro-combobox') as any)?.value === undefined,
+        { timeout: 3000 },
+      );
+
+      const result = await page.locator('auro-combobox').evaluate((el: any) => ({
+        value: el.value,
+        optionSelected: el.optionSelected,
+      }));
+
+      expect(result.value).toBeUndefined();
+      expect(result.optionSelected).toBeUndefined();
+    });
+
+    test('double-clicking set-invalid keeps value cleared', async ({ page }) => {
+      await waitForComboboxValue(page, initialValue);
+
+      // First click - confirm the invalid value is cleared
+      await page.locator('#set-invalid').click();
+      await page.waitForFunction(
+        () => (document.querySelector('auro-combobox') as any)?.value === undefined,
+        { timeout: 3000 },
+      );
+
+      // Second click - value should still be cleared
+      await page.locator('#set-invalid').click();
+      await page.waitForFunction(
+        () => (document.querySelector('auro-combobox') as any)?.value === undefined,
+        { timeout: 3000 },
+      );
+
+      const result = await page.locator('auro-combobox').evaluate((el: any) => ({
+        value: el.value,
+        optionSelected: el.optionSelected,
+      }));
+
+      expect(result.value).toBeUndefined();
+      expect(result.optionSelected).toBeUndefined();
+    });
+  });
+}

--- a/apps/svelte-framework/src/routes/+page.svelte
+++ b/apps/svelte-framework/src/routes/+page.svelte
@@ -2,6 +2,7 @@
 	const suites: { label: string; path: string }[] = [
 		{ label: 'auro-select: remount', path: '/select-remount' },
 		{ label: 'auro-select: remount (multiselect)', path: '/select-remount-multiselect' },
+		{ label: 'auro-combobox: remount', path: '/combobox-remount' },
 	];
 </script>
 

--- a/apps/svelte-framework/src/routes/combobox-remount/+page.svelte
+++ b/apps/svelte-framework/src/routes/combobox-remount/+page.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+	import '@aurodesignsystem/auro-formkit/auro-combobox';
+	import '@aurodesignsystem/auro-formkit/auro-menu';
+
+	const options: [string, string][] = [
+		['Apples', 'Apples'],
+		['Oranges', 'Oranges'],
+		['Peaches', 'Peaches'],
+		['Grapes', 'Grapes'],
+	];
+
+	let comboboxValue = $state<string>('Apples');
+	let showCombobox = $state<boolean>(true);
+
+	function setInvalidValue() {
+		const el = document.querySelector('auro-combobox') as any;
+		if (el) el.value = 'invalid-option';
+	}
+</script>
+
+<button id="toggle" onclick={() => (showCombobox = !showCombobox)}>
+	{showCombobox ? 'Hide' : 'Show'} Combobox
+</button>
+<button id="set-invalid" onclick={setInvalidValue}>Set Invalid Value</button>
+
+{#if showCombobox}
+	<auro-combobox behavior="filter" value={comboboxValue}>
+		<auro-menu>
+			{#each options as [value, label]}
+				<auro-menuoption {value}>{label}</auro-menuoption>
+			{/each}
+		</auro-menu>
+	</auro-combobox>
+{/if}
+
+<style>
+	#toggle {
+		margin-right: 1rem;
+	}
+</style>

--- a/apps/svelte-framework/tests/combobox-remount.spec.ts
+++ b/apps/svelte-framework/tests/combobox-remount.spec.ts
@@ -1,0 +1,3 @@
+import { comboboxRemountSuite } from '../../shared/combobox-remount.suite';
+
+comboboxRemountSuite('Svelte');


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Review Checklist:

- [ ] My update follows the CONTRIBUTING guidelines of this project
- [ ] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Add shared Playwright test coverage for auro-combobox remount behavior across React and Svelte framework playgrounds.

New Features:
- Add React and Svelte playground pages and navigation entries demonstrating auro-combobox remount behavior for manual and automated testing.

Tests:
- Introduce a shared combobox remount Playwright suite validating initial value, remount persistence, and invalid value handling for auro-combobox.
- Wire the shared combobox remount suite into new React and Svelte framework-specific test entries.