### PR TITLE
fix(dropdown): 'enter' in dialog selects highlighted option instead of closing bib AB#1516632

### DIFF
--- a/components/dropdown/src/auro-dropdown.js
+++ b/components/dropdown/src/auro-dropdown.js
@@ -248,6 +248,15 @@ export class AuroDropdown extends AuroElement {
       this.trigger.ariaActiveDescendantElement = null;
       this.trigger.removeAttribute('aria-activedescendant');
     }
+
+    // In fullscreen, focus stays on the close button while arrow keys
+    // highlight options via active-descendant. Without this flag the
+    // keyboard bridge clicks the close button on Enter (closing the
+    // bib without selecting). When true, the bridge skips the button
+    // click and forwards Enter to the parent to make the selection.
+    if (this.bibContent) {
+      this.bibContent.hasActiveDescendant = Boolean(element);
+    }
   }
 
   // function to define props used within the scope of this component

--- a/components/dropdown/src/auro-dropdown.js
+++ b/components/dropdown/src/auro-dropdown.js
@@ -255,7 +255,7 @@ export class AuroDropdown extends AuroElement {
     // bib without selecting). When true, the bridge skips the button
     // click and forwards Enter to the parent to make the selection.
     if (this.bibContent) {
-      this.bibContent.hasActiveDescendant = Boolean(element);
+      this.bibContent.hasActiveDescendant = this.isBibFullscreen && Boolean(element);
     }
   }
 

--- a/components/dropdown/src/auro-dropdownBib.js
+++ b/components/dropdown/src/auro-dropdownBib.js
@@ -44,6 +44,7 @@ export class AuroDropdownBib extends LitElement {
 
     this.shape = "rounded";
     this.matchWidth = false;
+    this.hasActiveDescendant = false;
   }
 
   static get styles() {
@@ -130,6 +131,17 @@ export class AuroDropdownBib extends LitElement {
        */
       dialogRole: {
         type: String
+      },
+
+      /**
+       * Set by auro-dropdown when a menu option is highlighted via
+       * aria-activedescendant. The dialog keyboard bridge checks this
+       * flag so that Enter selects the highlighted option instead of
+       * clicking the trigger button.
+       * @private
+       */
+      hasActiveDescendant: {
+        type: Boolean
       }
     };
   }

--- a/components/dropdown/src/auro-dropdownBib.js
+++ b/components/dropdown/src/auro-dropdownBib.js
@@ -276,15 +276,23 @@ export class AuroDropdownBib extends LitElement {
 
       // Custom elements (auro-button) don't get the native Enter→click
       // behavior that <button> has. Find the button in the composed path
-      // and click it directly.
+      // and click it directly — but only when no menu option is
+      // highlighted. In fullscreen mode focus stays on the close button
+      // while arrow keys move the active-descendant highlight through
+      // the listbox. If the user presses Enter with an option
+      // highlighted, the intent is to select that option, not to click
+      // the close button. In that case we fall through and bridge the
+      // Enter key to the parent component's keyboard strategy.
       if (event.key === 'Enter') {
-        const buttonSelector = 'button, [role="button"], auro-button, [auro-button]';
-        const btn = event.composedPath().find((el) => el.matches && el.matches(buttonSelector));
-        if (btn) {
-          event.preventDefault();
-          event.stopPropagation();
-          btn.click();
-          return;
+        if (!this.hasActiveDescendant) {
+          const buttonSelector = 'button, [role="button"], auro-button, [auro-button]';
+          const btn = event.composedPath().find((el) => el.matches && el.matches(buttonSelector));
+          if (btn) {
+            event.preventDefault();
+            event.stopPropagation();
+            btn.click();
+            return;
+          }
         }
       }
 

--- a/components/dropdown/src/auro-dropdownBib.js
+++ b/components/dropdown/src/auro-dropdownBib.js
@@ -407,6 +407,8 @@ export class AuroDropdownBib extends LitElement {
    * Closes the dialog.
    */
   close() {
+    this.hasActiveDescendant = false;
+
     const dialog = this.shadowRoot.querySelector('dialog');
 
     if (dialog && dialog.open) {

--- a/components/dropdown/src/auro-dropdownBib.js
+++ b/components/dropdown/src/auro-dropdownBib.js
@@ -137,7 +137,8 @@ export class AuroDropdownBib extends LitElement {
        * Set by auro-dropdown when a menu option is highlighted via
        * aria-activedescendant. The dialog keyboard bridge checks this
        * flag so that Enter selects the highlighted option instead of
-       * clicking the trigger button.
+       * activating the focused interactive element (e.g. the trigger
+       * button, or the bibtemplate close button in fullscreen).
        * @private
        */
       hasActiveDescendant: {

--- a/components/dropdown/src/auro-dropdownBib.js
+++ b/components/dropdown/src/auro-dropdownBib.js
@@ -213,7 +213,7 @@ export class AuroDropdownBib extends LitElement {
   /**
    * Forwards the dialog's native `cancel` event (fired on ESC) as
    * an `auro-bib-cancel` custom event so parent components can close.
-   * @param {HTMLDialogElement} dialog
+   * @param {HTMLDialogElement} dialog - The dialog element to attach the cancel listener to.
    * @private
    */
   _setupCancelHandler(dialog) {
@@ -257,7 +257,7 @@ export class AuroDropdownBib extends LitElement {
    *   is a secondary path for parent components that also listen for
    *   Escape keydown.
    *
-   * @param {HTMLDialogElement} dialog
+   * @param {HTMLDialogElement} dialog - The dialog element to attach the keyboard bridge to.
    * @private
    */
   _setupKeyboardBridge(dialog) {

--- a/components/select/stories/component.stories.ts
+++ b/components/select/stories/component.stories.ts
@@ -288,3 +288,73 @@ export const SelectSnowflakeOpen: Story = {
   },
 };
 
+// ─── §2.2.4  Fullscreen: Enter on close selects active option (P1) ─────────
+export const SelectFullscreenEnterOnCloseSelectsActiveOption: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  globals: {
+    viewport: {
+      value: 'xs',
+      isRotated: false
+    }
+  },
+  render: () => html`
+<auro-select fullscreenBreakpoint="xl">
+  <span slot="ariaLabel.bib.close">Close Popup</span>
+  <span slot="bib.fullscreen.headline">Bib Headline</span>
+  <span slot="label">Sort by</span>
+  <auro-menu>
+    <auro-menuoption value="stops">Stops</auro-menuoption>
+    <auro-menuoption value="price">Price</auro-menuoption>
+  </auro-menu>
+</auro-select>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-select') as any;
+    await el.updateComplete;
+
+    el.showBib();
+    await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+
+    const dropdown = el.dropdown;
+    const bib = dropdown.bibContent;
+
+    await expect(dropdown.isBibFullscreen).toBe(true);
+    await expect(el.isPopoverVisible).toBe(true);
+
+    // showModal() makes the select (outside the dialog) inert, so
+    // synthetic events can't drive the full navigation chain. Set
+    // the state directly to exercise the keyboard bridge logic.
+    const firstOption = el.querySelector('auro-menuoption[value="stops"]');
+    el.menu.menuService.setHighlightedOption(firstOption);
+    bib.hasActiveDescendant = true;
+
+    // Get the dialog element where the keyboard bridge listens
+    const dialog = bib.shadowRoot.querySelector('dialog');
+    await expect(dialog).toBeTruthy();
+
+    // Wire up the bib-side listener that mirrors what the select's
+    // keyboard strategy does in production. showModal() inertness
+    // prevents the bridged event from reaching the select, so we
+    // handle it on the bib — the test verifies the bridge forwards
+    // Enter instead of clicking the close button.
+    bib.addEventListener('keydown', (evt: KeyboardEvent) => {
+      if (evt.key === 'Enter') {
+        el.menu.makeSelection();
+      }
+    }, { once: true });
+
+    // Dispatch Enter directly on the dialog to exercise the bridge
+    dialog.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'Enter',
+      bubbles: true,
+      composed: true
+    }));
+    await new Promise((r) => setTimeout(r, 100));
+
+    // The bridge forwarded Enter → makeSelection() selected the
+    // highlighted option and closed the dialog.
+    await expect(el.value).toBe('stops');
+    await expect(el.isPopoverVisible).toBe(false);
+  },
+};
+

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -537,6 +537,30 @@ function runTest(mobileView) {
         await expect(el.value).to.equal('Apples');
         await expect(dropdown.isPopoverVisible).to.be.false;
       });
+
+      it('pressing Enter in fullscreen selects the highlighted option instead of closing the bib — dropdown mirrors active-descendant state to bib', async () => {
+        const el = await defaultFixture();
+        const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+        const trigger = dropdown.querySelector('[slot="trigger"]');
+        const bib = dropdown.bibContent;
+
+        trigger.click();
+        await expect(dropdown.isPopoverVisible).to.be.true;
+
+        // Wait for fullscreen dialog to settle (double-rAF used by focus migration)
+        await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+
+        // No active descendant before navigation
+        expect(bib.hasActiveDescendant).to.not.be.true;
+
+        // Navigate to first option
+        el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+        await elementUpdated(el);
+
+        // The dropdown should mirror active-descendant state to the bib
+        // so the keyboard bridge knows Enter should select, not close.
+        expect(bib.hasActiveDescendant).to.be.true;
+      });
     }
 
     it('Navigates the menu with arrow keys', async () => {

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -561,6 +561,23 @@ function runTest(mobileView) {
         // The dropdown should mirror active-descendant state to the bib
         // so the keyboard bridge knows Enter should select, not close.
         expect(bib.hasActiveDescendant).to.be.true;
+
+        // Simulate Enter originating from inside the fullscreen dialog while
+        // focus is on the close button, exercising the regression path.
+        const closeButton = el.bibtemplate.shadowRoot.querySelector('#closeButton');
+        expect(closeButton).to.exist;
+
+        closeButton.focus();
+        closeButton.dispatchEvent(new KeyboardEvent('keydown', {
+          key: 'Enter',
+          bubbles: true,
+          composed: true
+        }));
+        await elementUpdated(el);
+
+        // On first Enter, the focused option should be selected and the bib closed.
+        await expect(el.value).to.equal('Apples');
+        await expect(dropdown.isPopoverVisible).to.be.false;
       });
     }
 

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -538,7 +538,8 @@ function runTest(mobileView) {
         await expect(dropdown.isPopoverVisible).to.be.false;
       });
 
-      it('pressing Enter in fullscreen selects the highlighted option instead of closing the bib — dropdown mirrors active-descendant state to bib', async () => {
+      // ─── §2.2.4  Active-descendant state propagation to bib (P1) ─────────
+      it('dropdown mirrors hasActiveDescendant to bib so keyboard bridge distinguishes Enter-select from Enter-close', async () => {
         const el = await defaultFixture();
         const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
         const trigger = dropdown.querySelector('[slot="trigger"]');

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "dev:react": "concurrently \"npx turbo run build:watch --concurrency=20\" \"npm run dev:app:open --workspace=apps/react-framework\"",
     "lint": "turbo run lint",
     "test": "turbo run test && npm run test:frameworks",
+    "test:force": "turbo run test --force",
     "test:watch": "turbo run test:watch",
     "clean": "turbo run clean && rm -rf node_modules",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",


### PR DESCRIPTION
# Alaska Airlines Pull Request

In `auro-select`, In fullscreen mode, pressing `Enter` closes the bib without making a selection. A second Enter press is needed to actually select the option.

This happens because focus stays on the close button while arrow keys move the highlight through the listbox via `aria-activedescendant`. When the user presses Enter, the keyboard bridge in `auro-dropdownBib` finds the close button in the event's composed path, clicks it, and returns early — the Enter key never reaches the select's keyboard strategy to call `makeSelection()`.

### The Problem

In a fullscreen [Select](https://alaskaairlines.github.io/auro-formkit/pr-preview/pr-1394/select/readme.html) dialog:

- Highlight a selection using the arrow keys
- Press `Enter`: Note that the bib closes, but no selection is made.
- Press `Enter` a second time: Note the selection is made.

Selection should correctly occur the first time `Enter` key is hit.

**Before:**

https://github.com/user-attachments/assets/b531cc66-02f6-4ef4-8fad-40aa842a19c3


**After:**

https://github.com/user-attachments/assets/33ea7ed1-2f3c-4840-9075-cdf293a46779


### Fix

**`auro-dropdown.js`** — `setActiveDescendant()` now mirrors the active-descendant state to `bibContent.hasActiveDescendant`. This tells the bib whether a menu option is currently highlighted.

**`auro-dropdownBib.js`** — The keyboard bridge checks `this.hasActiveDescendant` before clicking a button on Enter. When an option is highlighted, the bridge skips the button click and forwards Enter to the parent component's keyboard strategy, which makes the selection.

### Scope

Only affects `auro-select` in fullscreen mode. Combobox and datepicker are unaffected — combobox calls `setActiveDescendant` on the input (not the dropdown), and datepicker doesn't use it at all. When `hasActiveDescendant` is not set, the bridge behaves exactly as before.

### Test plan

- [x] New unit test: `pressing Enter in fullscreen selects the highlighted option instead of closing the bib`
- [x] Existing tests pass (77 desktop + mobile tests)
- [x] Manual: open select at mobile width, arrow to an option, press Enter — option is selected on the first press
- [x] Manual: open select at mobile width, press Enter with no option highlighted — close button still works


## Review Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Adjust fullscreen select keyboard behavior so Enter selects the highlighted option instead of closing the dropdown bib.

Bug Fixes:
- Prevent Enter key from triggering the close button in fullscreen dropdown when a menu option is highlighted, allowing the parent component to handle selection instead.

Enhancements:
- Propagate active-descendant state from the dropdown to the bib to inform keyboard handling in fullscreen mode.
- Clarify JSDoc comments for dropdown bib dialog keyboard and cancel handlers.

Tests:
- Add a fullscreen select keyboard interaction test to ensure the dropdown mirrors active-descendant state to the bib and that Enter selects the highlighted option.

## Summary by Sourcery

Ensure fullscreen select dialogs treat Enter as selecting the highlighted option rather than closing the dropdown when a menu item is active.

Bug Fixes:
- Prevent the Enter key in fullscreen select dialogs from triggering the close button when a menu option is highlighted so the selection is made instead.

Enhancements:
- Mirror active-descendant state from the dropdown to the bib to guide keyboard bridge behavior in fullscreen mode.
- Clarify JSDoc comments for dropdown bib dialog cancel and keyboard bridge handlers.

Tests:
- Add a fullscreen select keyboard interaction test verifying that active-descendant state is mirrored to the bib and that Enter selects the highlighted option.