### PR TITLE
test(counter): adding test for counter-group's keyboard behaviors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ build-storybook.log
 .playwright
 apps/svelte-framework/test-results/.last-run.json
 test-results
+/apps/**/playwright-report

--- a/apps/react-framework/package.json
+++ b/apps/react-framework/package.json
@@ -10,7 +10,9 @@
     "preview": "vite preview",
     "clean:cache": "rm -rf node_modules/.vite",
     "pretest:framework": "npm run clean:cache && npx playwright install chromium",
-    "test:framework": "playwright test"
+    "test:framework": "playwright test",
+    "pretest:framework:report": "npm run clean:cache && npx playwright install chromium",
+    "test:framework:report": "playwright test --config=playwright.report.config.ts"
   },
   "dependencies": {
     "@aurodesignsystem/auro-formkit": "file:../../",

--- a/apps/react-framework/playwright.report.config.ts
+++ b/apps/react-framework/playwright.report.config.ts
@@ -1,0 +1,49 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Local visual report config — generates a slow-motion HTML report with video
+ * and trace capture for manual verification of framework integration tests.
+ *
+ * Per-framework:
+ *   npm run test:framework:report:react
+ *   npx playwright show-report playwright-report (from apps/react-framework)
+ *
+ * Unified (both frameworks):
+ *   npm run test:frameworks:report  (from repo root)
+ *   npm run test:frameworks:report:show
+ */
+export default defineConfig({
+  testDir: './tests',
+  testMatch: '**/*.spec.ts',
+  fullyParallel: false,
+  retries: 0,
+  reporter: [
+    ['html', { open: 'always' }],
+  ],
+  timeout: 15_000,
+  use: {
+    baseURL: 'http://localhost:5181',
+    headless: true,
+    launchOptions: {
+      slowMo: 300,
+    },
+    video: 'on',
+    trace: 'on',
+    viewport: { width: 1280, height: 800 },
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  ],
+  webServer: {
+    // Use `npm run dev:app -- --force` so Vite always invalidates its pre-bundle cache
+    // (`node_modules/.vite/`) before starting, ensuring tests run against
+    // freshly resolved dist files rather than a stale snapshot.
+    command: 'npm run dev:app -- --force',
+    url: 'http://localhost:5181',
+    // Always launch a fresh server. `reuseExistingServer: true` would silently
+    // run tests against an already-running server that may be serving stale
+    // dist files, producing false positives.
+    reuseExistingServer: false,
+    timeout: 120_000,
+  },
+});

--- a/apps/react-framework/src/App.tsx
+++ b/apps/react-framework/src/App.tsx
@@ -3,6 +3,9 @@ import Home from './pages/Home';
 import SelectRemount from './pages/SelectRemount';
 import SelectRemountMultiselect from './pages/SelectRemountMultiselect';
 import ComboboxRemount from './pages/ComboboxRemount';
+import CounterDropdown from './pages/CounterDropdown';
+import CounterRemount from './pages/CounterRemount';
+import SingleCounterRemount from './pages/SingleCounterRemount';
 
 export default function App() {
   return (
@@ -11,6 +14,9 @@ export default function App() {
       <Route path="/select-remount" component={SelectRemount} />
       <Route path="/select-remount-multiselect" component={SelectRemountMultiselect} />
       <Route path="/combobox-remount" component={ComboboxRemount} />
+      <Route path="/counter-dropdown" component={CounterDropdown} />
+      <Route path="/counter-remount" component={CounterRemount} />
+      <Route path="/single-counter-remount" component={SingleCounterRemount} />
     </Router>
   );
 }

--- a/apps/react-framework/src/main.tsx
+++ b/apps/react-framework/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client'
 import '@aurodesignsystem/auro-formkit/auro-select'
 import '@aurodesignsystem/auro-formkit/auro-combobox'
 import '@aurodesignsystem/auro-formkit/auro-menu'
+import '@aurodesignsystem/auro-formkit/auro-counter'
 import './index.css'
 import App from './App.tsx'
 

--- a/apps/react-framework/src/pages/CounterDropdown.tsx
+++ b/apps/react-framework/src/pages/CounterDropdown.tsx
@@ -21,7 +21,6 @@ export default function CounterDropdown() {
         <span slot="ariaLabel.bib.close">Close</span>
         <span slot="bib.fullscreen.headline">Passengers</span>
         <div slot="label">Passengers</div>
-        <div slot="valueText">Open passengers</div>
         <auro-counter>
           Adults
           <span slot="description">18 years or older</span>

--- a/apps/react-framework/src/pages/CounterDropdown.tsx
+++ b/apps/react-framework/src/pages/CounterDropdown.tsx
@@ -1,0 +1,40 @@
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      'auro-counter-group': React.HTMLAttributes<HTMLElement> & {
+        isDropdown?: boolean | '';
+        min?: string | number;
+        max?: string | number;
+      };
+      'auro-counter': React.HTMLAttributes<HTMLElement> & {
+        min?: string | number;
+        max?: string | number;
+      };
+    }
+  }
+}
+
+export default function CounterDropdown() {
+  return (
+    <div>
+      <auro-counter-group isDropdown>
+        <span slot="ariaLabel.bib.close">Close</span>
+        <span slot="bib.fullscreen.headline">Passengers</span>
+        <div slot="label">Passengers</div>
+        <div slot="valueText">Open passengers</div>
+        <auro-counter>
+          Adults
+          <span slot="description">18 years or older</span>
+        </auro-counter>
+        <auro-counter>
+          Children
+          <span slot="description">2–17 years</span>
+        </auro-counter>
+        <auro-counter>
+          Infants
+          <span slot="description">Under 2 years</span>
+        </auro-counter>
+      </auro-counter-group>
+    </div>
+  );
+}

--- a/apps/react-framework/src/pages/CounterRemount.tsx
+++ b/apps/react-framework/src/pages/CounterRemount.tsx
@@ -1,0 +1,54 @@
+import { useState } from 'react';
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      'auro-counter-group': React.HTMLAttributes<HTMLElement> & {
+        isDropdown?: boolean | '';
+      };
+      'auro-counter': React.HTMLAttributes<HTMLElement> & {
+        value?: number;
+        min?: number;
+        max?: number;
+      };
+    }
+  }
+}
+
+const INITIAL_VALUES = [2, 1, 0];
+
+function CounterGroupWrapper() {
+  return (
+    <auro-counter-group isDropdown>
+      <span slot="ariaLabel.bib.close">Close</span>
+      <span slot="bib.fullscreen.headline">Passengers</span>
+      <div slot="label">Passengers</div>
+      <div slot="valueText">Open passengers</div>
+      <auro-counter name="adults" value={String(INITIAL_VALUES[0])}>
+        Adults
+        <span slot="description">18 years or older</span>
+      </auro-counter>
+      <auro-counter name="children" value={String(INITIAL_VALUES[1])}>
+        Children
+        <span slot="description">2–17 years</span>
+      </auro-counter>
+      <auro-counter name="infants" value={String(INITIAL_VALUES[2])}>
+        Infants
+        <span slot="description">Under 2 years</span>
+      </auro-counter>
+    </auro-counter-group>
+  );
+}
+
+export default function CounterRemount() {
+  const [show, setShow] = useState(true);
+
+  return (
+    <div>
+      <button id="toggle" onClick={() => setShow((s) => !s)}>
+        {show ? 'Hide' : 'Show'} Counter
+      </button>
+      {show && <CounterGroupWrapper />}
+    </div>
+  );
+}

--- a/apps/react-framework/src/pages/CounterRemount.tsx
+++ b/apps/react-framework/src/pages/CounterRemount.tsx
@@ -23,7 +23,6 @@ function CounterGroupWrapper() {
       <span slot="ariaLabel.bib.close">Close</span>
       <span slot="bib.fullscreen.headline">Passengers</span>
       <div slot="label">Passengers</div>
-      <div slot="valueText">Open passengers</div>
       <auro-counter name="adults" value={String(INITIAL_VALUES[0])}>
         Adults
         <span slot="description">18 years or older</span>

--- a/apps/react-framework/src/pages/Home.tsx
+++ b/apps/react-framework/src/pages/Home.tsx
@@ -5,6 +5,8 @@ const SUITES: { label: string; path: string }[] = [
   { label: 'auro-select: remount (multiselect)', path: '/select-remount-multiselect' },
   { label: 'auro-combobox: remount', path: '/combobox-remount' },
   { label: 'auro-counter-group: dropdown keyboard', path: '/counter-dropdown' },
+  { label: 'auro-counter-group: remount', path: '/counter-remount' },
+  { label: 'auro-counter: remount (single)', path: '/single-counter-remount' },
 ];
 
 export default function Home() {

--- a/apps/react-framework/src/pages/Home.tsx
+++ b/apps/react-framework/src/pages/Home.tsx
@@ -4,6 +4,7 @@ const SUITES: { label: string; path: string }[] = [
   { label: 'auro-select: remount', path: '/select-remount' },
   { label: 'auro-select: remount (multiselect)', path: '/select-remount-multiselect' },
   { label: 'auro-combobox: remount', path: '/combobox-remount' },
+  { label: 'auro-counter-group: dropdown keyboard', path: '/counter-dropdown' },
 ];
 
 export default function Home() {

--- a/apps/react-framework/src/pages/SingleCounterRemount.tsx
+++ b/apps/react-framework/src/pages/SingleCounterRemount.tsx
@@ -1,0 +1,37 @@
+import { useState } from 'react';
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      'auro-counter': React.HTMLAttributes<HTMLElement> & {
+        value?: string;
+        min?: string;
+        max?: string;
+      };
+    }
+  }
+}
+
+const INITIAL_VALUE = 3;
+
+function CounterWrapper() {
+  return (
+    <auro-counter value={String(INITIAL_VALUE)} min="0" max="9">
+      Bags
+      <span slot="description">Number of checked bags</span>
+    </auro-counter>
+  );
+}
+
+export default function SingleCounterRemount() {
+  const [show, setShow] = useState(true);
+
+  return (
+    <div>
+      <button id="toggle" onClick={() => setShow((s) => !s)}>
+        {show ? 'Hide' : 'Show'} Counter
+      </button>
+      {show && <CounterWrapper />}
+    </div>
+  );
+}

--- a/apps/react-framework/tests/counter-dropdown.spec.ts
+++ b/apps/react-framework/tests/counter-dropdown.spec.ts
@@ -1,0 +1,3 @@
+import { counterDropdownSuite } from '../../shared/counter-dropdown.suite';
+
+counterDropdownSuite('React');

--- a/apps/react-framework/tests/counter-remount.spec.ts
+++ b/apps/react-framework/tests/counter-remount.spec.ts
@@ -1,0 +1,3 @@
+import { counterRemountSuite } from '../../shared/counter-remount.suite';
+
+counterRemountSuite('React');

--- a/apps/react-framework/tests/single-counter-remount.spec.ts
+++ b/apps/react-framework/tests/single-counter-remount.spec.ts
@@ -1,0 +1,3 @@
+import { singleCounterRemountSuite } from '../../shared/single-counter-remount.suite';
+
+singleCounterRemountSuite('React');

--- a/apps/shared/counter-dropdown.suite.ts
+++ b/apps/shared/counter-dropdown.suite.ts
@@ -15,7 +15,7 @@ export function counterDropdownSuite(framework: string) {
     });
 
     test('dropdown opens and all counter controls are visible', async ({ page }) => {
-      await page.getByText('Open passengers').click();
+      await page.locator('#triggerFocus').click();
       await expect(page.getByRole('button', { name: '+' }).first()).toBeVisible({ timeout: 3_000 });
       await expect(page.getByRole('button', { name: '+' })).toHaveCount(3);
     });
@@ -23,7 +23,7 @@ export function counterDropdownSuite(framework: string) {
     // Regression for PR #1398 — nativeFocusableContent=true must let Tab pass through
     // instead of the keyboard bridge intercepting it and closing the dropdown.
     test('Tab moves focus to second counter and keeps dropdown open', async ({ page }) => {
-      await page.getByText('Open passengers').click();
+      await page.locator('#triggerFocus').click();
 
       const plusButtons = page.getByRole('button', { name: '+' });
       await expect(plusButtons).toHaveCount(3, { timeout: 3_000 });
@@ -47,7 +47,7 @@ export function counterDropdownSuite(framework: string) {
     });
 
     test('Shift+Tab moves focus backward and keeps dropdown open', async ({ page }) => {
-      await page.getByText('Open passengers').click();
+      await page.locator('#triggerFocus').click();
 
       const plusButtons = page.getByRole('button', { name: '+' });
       await expect(plusButtons).toHaveCount(3, { timeout: 3_000 });

--- a/apps/shared/counter-dropdown.suite.ts
+++ b/apps/shared/counter-dropdown.suite.ts
@@ -32,12 +32,10 @@ export function counterDropdownSuite(framework: string) {
       // counterControl part with tabindex=0; the inner +/- buttons have
       // tabindex="-1" and are not in the Tab sequence. First Tab lands on counter 1.
       await page.keyboard.press('Tab');
-      await page.waitForTimeout(100);
       await expect(page.locator('auro-counter').nth(0)).toBeFocused();
 
       // Second Tab moves focus to counter 2, keeping the dropdown open.
       await page.keyboard.press('Tab');
-      await page.waitForTimeout(100);
 
       // After two Tabs, document.activeElement is the second auro-counter host element.
       await expect(page.locator('auro-counter').nth(1)).toBeFocused();
@@ -54,16 +52,13 @@ export function counterDropdownSuite(framework: string) {
 
       // Tab into the bib twice so focus lands on counter 2 natively.
       await page.keyboard.press('Tab');
-      await page.waitForTimeout(100);
       await expect(page.locator('auro-counter').nth(0)).toBeFocused();
 
       await page.keyboard.press('Tab');
-      await page.waitForTimeout(100);
       await expect(page.locator('auro-counter').nth(1)).toBeFocused();
 
       // Shift+Tab moves focus back to counter 1, keeping the dropdown open.
       await page.keyboard.press('Shift+Tab');
-      await page.waitForTimeout(100);
       await expect(page.locator('auro-counter').nth(0)).toBeFocused();
 
       // Dropdown must still be open — all 3 plus buttons still reachable

--- a/apps/shared/counter-dropdown.suite.ts
+++ b/apps/shared/counter-dropdown.suite.ts
@@ -1,0 +1,73 @@
+import { test, expect, type Page } from '@playwright/test';
+
+async function waitForReady(page: Page) {
+  await page.waitForFunction(
+    () => customElements.get('auro-counter-group') !== undefined,
+    { timeout: 10_000 },
+  );
+}
+
+export function counterDropdownSuite(framework: string) {
+  test.describe(`auro-counter-group (dropdown) in ${framework}`, () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto('/counter-dropdown');
+      await waitForReady(page);
+    });
+
+    test('dropdown opens and all counter controls are visible', async ({ page }) => {
+      await page.getByText('Open passengers').click();
+      await expect(page.getByRole('button', { name: '+' }).first()).toBeVisible({ timeout: 3_000 });
+      await expect(page.getByRole('button', { name: '+' })).toHaveCount(3);
+    });
+
+    // Regression for PR #1398 — nativeFocusableContent=true must let Tab pass through
+    // instead of the keyboard bridge intercepting it and closing the dropdown.
+    test('Tab moves focus to second counter and keeps dropdown open', async ({ page }) => {
+      await page.getByText('Open passengers').click();
+
+      const plusButtons = page.getByRole('button', { name: '+' });
+      await expect(plusButtons).toHaveCount(3, { timeout: 3_000 });
+
+      // Tab from the trigger into the bib. Each auro-counter host element has a
+      // counterControl part with tabindex=0; the inner +/- buttons have
+      // tabindex="-1" and are not in the Tab sequence. First Tab lands on counter 1.
+      await page.keyboard.press('Tab');
+      await page.waitForTimeout(100);
+      await expect(page.locator('auro-counter').nth(0)).toBeFocused();
+
+      // Second Tab moves focus to counter 2, keeping the dropdown open.
+      await page.keyboard.press('Tab');
+      await page.waitForTimeout(100);
+
+      // After two Tabs, document.activeElement is the second auro-counter host element.
+      await expect(page.locator('auro-counter').nth(1)).toBeFocused();
+
+      // Dropdown must still be open — all 3 plus buttons still reachable
+      await expect(plusButtons).toHaveCount(3);
+    });
+
+    test('Shift+Tab moves focus backward and keeps dropdown open', async ({ page }) => {
+      await page.getByText('Open passengers').click();
+
+      const plusButtons = page.getByRole('button', { name: '+' });
+      await expect(plusButtons).toHaveCount(3, { timeout: 3_000 });
+
+      // Tab into the bib twice so focus lands on counter 2 natively.
+      await page.keyboard.press('Tab');
+      await page.waitForTimeout(100);
+      await expect(page.locator('auro-counter').nth(0)).toBeFocused();
+
+      await page.keyboard.press('Tab');
+      await page.waitForTimeout(100);
+      await expect(page.locator('auro-counter').nth(1)).toBeFocused();
+
+      // Shift+Tab moves focus back to counter 1, keeping the dropdown open.
+      await page.keyboard.press('Shift+Tab');
+      await page.waitForTimeout(100);
+      await expect(page.locator('auro-counter').nth(0)).toBeFocused();
+
+      // Dropdown must still be open — all 3 plus buttons still reachable
+      await expect(plusButtons).toHaveCount(3);
+    });
+  });
+}

--- a/apps/shared/counter-remount.suite.ts
+++ b/apps/shared/counter-remount.suite.ts
@@ -1,0 +1,87 @@
+import { test, expect, type Page } from '@playwright/test';
+
+/** Named initial values — keys match the `name` attributes on each auro-counter. */
+const DEFAULT_INITIAL_VALUES: Record<string, number> = {
+  adults: 2,
+  children: 1,
+  infants: 0,
+};
+
+/**
+ * Poll until the auro-counter-group's computed `value` object matches the
+ * expected map and every named counter's individual `value` also matches.
+ */
+async function waitForGroupValue(
+  page: Page,
+  expected: Record<string, number>,
+  timeout = 3000,
+) {
+  await page.waitForFunction(
+    (exp: Record<string, number>) => {
+      const group = document.querySelector('auro-counter-group') as any;
+      if (!group?.value) return false;
+      return Object.entries(exp).every(([key, val]) => group.value[key] === val);
+    },
+    expected,
+    { timeout },
+  );
+}
+
+interface SuiteOptions {
+  route: string;
+  initialValues: Record<string, number>;
+}
+
+export function counterRemountSuite(framework: string, options?: SuiteOptions) {
+  const { route, initialValues } = options ?? {
+    route: '/counter-remount',
+    initialValues: DEFAULT_INITIAL_VALUES,
+  };
+
+  test.describe(`auro-counter-group (remount) in ${framework}`, () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto(route);
+      await page.waitForFunction(
+        () => customElements.get('auro-counter-group') !== undefined,
+        { timeout: 10_000 },
+      );
+    });
+
+    test('initial values are set on first render', async ({ page }) => {
+      await waitForGroupValue(page, initialValues);
+
+      // Verify group-level computed value object
+      const groupValue = await page.locator('auro-counter-group').evaluate((el: any) => el.value);
+      expect(groupValue).toMatchObject(initialValues);
+
+      // Verify each individual counter matches its named entry
+      const counterValues = await page.locator('auro-counter').evaluateAll(
+        (els: any[]) => Object.fromEntries(els.map((el) => [el.getAttribute('name'), el.value])),
+      );
+      expect(counterValues).toMatchObject(initialValues);
+    });
+
+    test('values are restored after DOM remount', async ({ page }) => {
+      await waitForGroupValue(page, initialValues);
+
+      // Unmount
+      await page.locator('#toggle').click();
+      await page.waitForSelector('auro-counter-group', { state: 'detached' });
+
+      // Remount
+      await page.locator('#toggle').click();
+      await page.waitForSelector('auro-counter-group', { state: 'attached' });
+
+      await waitForGroupValue(page, initialValues);
+
+      // Verify group-level computed value object is restored
+      const groupValue = await page.locator('auro-counter-group').evaluate((el: any) => el.value);
+      expect(groupValue).toMatchObject(initialValues);
+
+      const counterValues = await page.locator('auro-counter').evaluateAll(
+        (els: any[]) => Object.fromEntries(els.map((el) => [el.getAttribute('name'), el.value])),
+      );
+      expect(counterValues).toMatchObject(initialValues);
+    });
+  });
+}

--- a/apps/shared/counter-remount.suite.ts
+++ b/apps/shared/counter-remount.suite.ts
@@ -77,6 +77,16 @@ export function counterRemountSuite(framework: string, options?: SuiteOptions) {
       await page.locator('#toggle').click();
       await page.waitForSelector('auro-counter-group', { state: 'attached' });
 
+      // Wait for the custom element to finish upgrading after remount before
+      // polling for values — mirrors the beforeEach guard on first render.
+      await page.waitForFunction(
+        () => {
+          const group = document.querySelector('auro-counter-group') as any;
+          return group != null && typeof group.value === 'object' && group.value !== null;
+        },
+        { timeout: 10_000 },
+      );
+
       await waitForGroupValue(page, initialValues);
 
       // Verify group-level computed value object is restored

--- a/apps/shared/counter-remount.suite.ts
+++ b/apps/shared/counter-remount.suite.ts
@@ -41,6 +41,11 @@ export function counterRemountSuite(framework: string, options?: SuiteOptions) {
   test.describe(`auro-counter-group (remount) in ${framework}`, () => {
     test.beforeEach(async ({ page }) => {
       await page.goto(route);
+      // Wait for all framework JS (including SvelteKit's dynamic page imports) to
+      // finish executing before interacting with the page. Without this, the onclick
+      // handler on #toggle may not yet be attached on slower CI machines (Node 20),
+      // causing waitForSelector('detached') to time out.
+      await page.waitForLoadState('networkidle');
       await page.waitForFunction(
         () => customElements.get('auro-counter-group') !== undefined,
         { timeout: 10_000 },

--- a/apps/shared/single-counter-remount.suite.ts
+++ b/apps/shared/single-counter-remount.suite.ts
@@ -1,0 +1,56 @@
+import { test, expect, type Page } from '@playwright/test';
+
+const DEFAULT_INITIAL_VALUE = 3;
+
+/** Poll until the standalone auro-counter's value matches or we time out. */
+async function waitForCounterValue(page: Page, expected: number, timeout = 3000) {
+  await page.waitForFunction(
+    (val: number) => (document.querySelector('auro-counter') as any)?.value === val,
+    expected,
+    { timeout },
+  );
+}
+
+interface SuiteOptions {
+  route: string;
+  initialValue: number;
+}
+
+export function singleCounterRemountSuite(framework: string, options?: SuiteOptions) {
+  const { route, initialValue } = options ?? {
+    route: '/single-counter-remount',
+    initialValue: DEFAULT_INITIAL_VALUE,
+  };
+
+  test.describe(`auro-counter (single, remount) in ${framework}`, () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto(route);
+      await page.waitForFunction(
+        () => customElements.get('auro-counter') !== undefined,
+        { timeout: 10_000 },
+      );
+    });
+
+    test('initial value is set on first render', async ({ page }) => {
+      await waitForCounterValue(page, initialValue);
+      const value = await page.locator('auro-counter').evaluate((el: any) => el.value);
+      expect(value).toBe(initialValue);
+    });
+
+    test('value is restored after DOM remount', async ({ page }) => {
+      await waitForCounterValue(page, initialValue);
+
+      // Unmount
+      await page.locator('#toggle').click();
+      await page.waitForSelector('auro-counter', { state: 'detached' });
+
+      // Remount
+      await page.locator('#toggle').click();
+      await page.waitForSelector('auro-counter', { state: 'attached' });
+
+      await waitForCounterValue(page, initialValue);
+      const value = await page.locator('auro-counter').evaluate((el: any) => el.value);
+      expect(value).toBe(initialValue);
+    });
+  });
+}

--- a/apps/svelte-framework/package.json
+++ b/apps/svelte-framework/package.json
@@ -13,7 +13,9 @@
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"clean:cache": "rm -rf .svelte-kit node_modules/.vite",
 		"pretest:framework": "npm run clean:cache && npx playwright install chromium",
-		"test:framework": "playwright test"
+		"test:framework": "playwright test",
+		"pretest:framework:report": "npm run clean:cache && npx playwright install chromium",
+		"test:framework:report": "playwright test --config=playwright.report.config.ts"
 	},
 	"dependencies": {
 		"@aurodesignsystem/auro-formkit": "file:../../"

--- a/apps/svelte-framework/playwright.report.config.ts
+++ b/apps/svelte-framework/playwright.report.config.ts
@@ -1,0 +1,49 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Local visual report config — generates a slow-motion HTML report with video
+ * and trace capture for manual verification of framework integration tests.
+ *
+ * Per-framework:
+ *   npm run test:framework:report:svelte
+ *   npx playwright show-report playwright-report (from apps/svelte-framework)
+ *
+ * Unified (both frameworks):
+ *   npm run test:frameworks:report  (from repo root)
+ *   npm run test:frameworks:report:show
+ */
+export default defineConfig({
+  testDir: './tests',
+  testMatch: '**/*.spec.ts',
+  fullyParallel: false,
+  retries: 0,
+  reporter: [
+    ['html', { open: 'always' }],
+  ],
+  timeout: 15_000,
+  use: {
+    baseURL: 'http://localhost:5182',
+    headless: true,
+    launchOptions: {
+      slowMo: 300,
+    },
+    video: 'on',
+    trace: 'on',
+    viewport: { width: 1280, height: 800 },
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  ],
+  webServer: {
+    // Use `npm run dev:app -- --force` so Vite always invalidates its pre-bundle cache
+    // (`node_modules/.vite/`) before starting, ensuring tests run against
+    // freshly resolved dist files rather than a stale snapshot.
+    command: 'npm run dev:app -- --force',
+    url: 'http://localhost:5182',
+    // Always launch a fresh server. `reuseExistingServer: true` would silently
+    // run tests against an already-running server that may be serving stale
+    // dist files, producing false positives.
+    reuseExistingServer: false,
+    timeout: 120_000,
+  },
+});

--- a/apps/svelte-framework/src/routes/+page.svelte
+++ b/apps/svelte-framework/src/routes/+page.svelte
@@ -4,6 +4,8 @@
 		{ label: 'auro-select: remount (multiselect)', path: '/select-remount-multiselect' },
 		{ label: 'auro-combobox: remount', path: '/combobox-remount' },
 		{ label: 'auro-counter-group: dropdown keyboard', path: '/counter-dropdown' },
+		{ label: 'auro-counter-group: remount', path: '/counter-remount' },
+		{ label: 'auro-counter: remount (single)', path: '/single-counter-remount' },
 	];
 </script>
 

--- a/apps/svelte-framework/src/routes/+page.svelte
+++ b/apps/svelte-framework/src/routes/+page.svelte
@@ -3,6 +3,7 @@
 		{ label: 'auro-select: remount', path: '/select-remount' },
 		{ label: 'auro-select: remount (multiselect)', path: '/select-remount-multiselect' },
 		{ label: 'auro-combobox: remount', path: '/combobox-remount' },
+		{ label: 'auro-counter-group: dropdown keyboard', path: '/counter-dropdown' },
 	];
 </script>
 

--- a/apps/svelte-framework/src/routes/counter-dropdown/+page.svelte
+++ b/apps/svelte-framework/src/routes/counter-dropdown/+page.svelte
@@ -6,7 +6,6 @@
 	<span slot="ariaLabel.bib.close">Close</span>
 	<span slot="bib.fullscreen.headline">Passengers</span>
 	<div slot="label">Passengers</div>
-	<div slot="valueText">Open passengers</div>
 	<auro-counter>
 		Adults
 		<span slot="description">18 years or older</span>

--- a/apps/svelte-framework/src/routes/counter-dropdown/+page.svelte
+++ b/apps/svelte-framework/src/routes/counter-dropdown/+page.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import '@aurodesignsystem/auro-formkit/auro-counter';
+</script>
+
+<auro-counter-group isDropdown>
+	<span slot="ariaLabel.bib.close">Close</span>
+	<span slot="bib.fullscreen.headline">Passengers</span>
+	<div slot="label">Passengers</div>
+	<div slot="valueText">Open passengers</div>
+	<auro-counter>
+		Adults
+		<span slot="description">18 years or older</span>
+	</auro-counter>
+	<auro-counter>
+		Children
+		<span slot="description">2–17 years</span>
+	</auro-counter>
+	<auro-counter>
+		Infants
+		<span slot="description">Under 2 years</span>
+	</auro-counter>
+</auro-counter-group>

--- a/apps/svelte-framework/src/routes/counter-remount/+page.svelte
+++ b/apps/svelte-framework/src/routes/counter-remount/+page.svelte
@@ -14,7 +14,6 @@
 		<span slot="ariaLabel.bib.close">Close</span>
 		<span slot="bib.fullscreen.headline">Passengers</span>
 		<div slot="label">Passengers</div>
-		<div slot="valueText">Open passengers</div>
 		<auro-counter name="adults" value={String(initialValues[0])}>
 			Adults
 			<span slot="description">18 years or older</span>

--- a/apps/svelte-framework/src/routes/counter-remount/+page.svelte
+++ b/apps/svelte-framework/src/routes/counter-remount/+page.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	import '@aurodesignsystem/auro-formkit/auro-counter';
+
+	const initialValues = [2, 1, 0];
+	let showCounter = $state<boolean>(true);
+</script>
+
+<button id="toggle" onclick={() => (showCounter = !showCounter)}>
+	{showCounter ? 'Hide' : 'Show'} Counter
+</button>
+
+{#if showCounter}
+	<auro-counter-group isDropdown>
+		<span slot="ariaLabel.bib.close">Close</span>
+		<span slot="bib.fullscreen.headline">Passengers</span>
+		<div slot="label">Passengers</div>
+		<div slot="valueText">Open passengers</div>
+		<auro-counter name="adults" value={String(initialValues[0])}>
+			Adults
+			<span slot="description">18 years or older</span>
+		</auro-counter>
+		<auro-counter name="children" value={String(initialValues[1])}>
+			Children
+			<span slot="description">2–17 years</span>
+		</auro-counter>
+		<auro-counter name="infants" value={String(initialValues[2])}>
+			Infants
+			<span slot="description">Under 2 years</span>
+		</auro-counter>
+	</auro-counter-group>
+{/if}
+
+<style>
+	#toggle {
+		margin-bottom: 1rem;
+	}
+</style>

--- a/apps/svelte-framework/src/routes/single-counter-remount/+page.svelte
+++ b/apps/svelte-framework/src/routes/single-counter-remount/+page.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import '@aurodesignsystem/auro-formkit/auro-counter';
+
+	const initialValue = 3;
+	let showCounter = $state<boolean>(true);
+</script>
+
+<button id="toggle" onclick={() => (showCounter = !showCounter)}>
+	{showCounter ? 'Hide' : 'Show'} Counter
+</button>
+
+{#if showCounter}
+	<auro-counter value={String(initialValue)} min="0" max="9">
+		Bags
+		<span slot="description">Number of checked bags</span>
+	</auro-counter>
+{/if}
+
+<style>
+	#toggle {
+		margin-bottom: 1rem;
+	}
+</style>

--- a/apps/svelte-framework/tests/counter-dropdown.spec.ts
+++ b/apps/svelte-framework/tests/counter-dropdown.spec.ts
@@ -1,0 +1,3 @@
+import { counterDropdownSuite } from '../../shared/counter-dropdown.suite';
+
+counterDropdownSuite('Svelte');

--- a/apps/svelte-framework/tests/counter-remount.spec.ts
+++ b/apps/svelte-framework/tests/counter-remount.spec.ts
@@ -1,0 +1,3 @@
+import { counterRemountSuite } from '../../shared/counter-remount.suite';
+
+counterRemountSuite('Svelte');

--- a/apps/svelte-framework/tests/single-counter-remount.spec.ts
+++ b/apps/svelte-framework/tests/single-counter-remount.spec.ts
@@ -1,0 +1,3 @@
+import { singleCounterRemountSuite } from '../../shared/single-counter-remount.suite';
+
+singleCounterRemountSuite('Svelte');

--- a/components/counter/docs/api.md
+++ b/components/counter/docs/api.md
@@ -67,7 +67,7 @@ The `auro-counter` element provides a flexible counter interface with increment 
 | `min`        | `min`        | `number`                 |             | The minimum value for the counter.               |
 | `onDark`     | `onDark`     | `boolean`                |             | DEPRECATED - use `appearance="inverse"` instead. |
 | `validity`   | `validity`   | `string`                 |             | The validity state of the counter.               |
-| `value`      | `value`      | `number`                 |             | The current value of the counter.                |
+| `value`      | `value`      | `number \| undefined`    |             | Gets the current value of the counter.           |
 
 ## Methods
 

--- a/components/counter/src/auro-counter-group.js
+++ b/components/counter/src/auro-counter-group.js
@@ -349,6 +349,7 @@ export class AuroCounterGroup extends AuroElement {
       counter.addEventListener("input", this.updateValue);
       counter.addEventListener("auroFormElement-validated", this.updateValidity);
     });
+    this.updateValue();
   }
 
   /**
@@ -478,6 +479,8 @@ export class AuroCounterGroup extends AuroElement {
       counter.addEventListener("input", this.updateValue);
       counter.addEventListener("auroFormElement-validated", this.updateValidity);
     });
+
+    this.updateValue();
 
     if (this.isDropdown) {
       this.configureBibtemplate();

--- a/components/counter/src/auro-counter.js
+++ b/components/counter/src/auro-counter.js
@@ -104,6 +104,29 @@ export class AuroCounter extends LitElement {
   }
 
   /**
+   * Gets the current value of the counter.
+   * @returns {number|undefined} The current value of the counter, or undefined if the value is not set or invalid.
+   */
+  get value() {
+    return this._value;
+  }
+
+  /**
+   * Sets the value of the counter. If the provided value is undefined, null, or cannot be converted to a number, the internal value will be set to undefined.
+   * @param {number|string|undefined|null} val - The value to set for the counter. Can be a number, a string that can be converted to a number, undefined, or null.
+   */
+  set value(val) {
+    const old = this._value;
+    if (val === undefined || val === null) {
+      this._value = undefined;
+    } else {
+      const num = Number(val);
+      this._value = Number.isNaN(num) ? undefined : num;
+    }
+    this.requestUpdate('value', old);
+  }
+
+  /**
    * Defines reactive properties for the component.
    * @returns {Object} Property configuration.
    */

--- a/components/counter/test/auro-counter-group.test.js
+++ b/components/counter/test/auro-counter-group.test.js
@@ -344,35 +344,22 @@ describe('auro-counter-group: keyboard navigation', () => {
     await elementUpdated(el);
     expect(el.dropdown.isPopoverVisible).to.be.false;
   });
-});
 
-describe('auro-counter-group: fullscreen dialog', () => {
-  it('focuses close button when fullscreen dialog opens', async () => {
+  it('sets nativeFocusableContent on bibContent when dropdown is toggled', async () => {
     const el = await fixture(html`
       <auro-counter-group isDropdown>
-        <span slot="bib.fullscreen.headline">Travelers</span>
         <auro-counter value="2">Counter 1</auro-counter>
         <auro-counter value="3">Counter 2</auro-counter>
       </auro-counter-group>
     `);
 
-    // Open dropdown in desktop (non-modal) mode
     el.dropdown.show();
     await elementUpdated(el);
 
-    // Set fullscreen on bibtemplate to render the close button
-    el.bibtemplate.isFullscreen = true;
-    await el.bibtemplate.updateComplete;
-
-    // Call focusCloseButton (the method under test)
-    el.bibtemplate.focusCloseButton();
-
-    const closeBtn = el.bibtemplate.shadowRoot.querySelector('#closeButton');
-    expect(closeBtn).to.exist;
-    expect(el.bibtemplate.shadowRoot.activeElement).to.equal(closeBtn);
+    expect(el.dropdown.bibContent.nativeFocusableContent).to.be.true;
   });
 
-  it('Tab key closes fullscreen dialog', async () => {
+  it('does not close dropdown when Tab is pressed while bib is open', async () => {
     const el = await fixture(html`
       <auro-counter-group isDropdown>
         <auro-counter value="2">Counter 1</auro-counter>
@@ -380,18 +367,14 @@ describe('auro-counter-group: fullscreen dialog', () => {
       </auro-counter-group>
     `);
 
-    // Open dropdown in desktop (non-modal) mode
     el.dropdown.show();
     await elementUpdated(el);
     expect(el.dropdown.isPopoverVisible).to.be.true;
 
-    // Set isBibFullscreen and immediately dispatch Tab —
-    // the synchronous keydown handler reads isBibFullscreen before
-    // Lit's async update can re-open the dialog in modal mode
-    el.dropdown.isBibFullscreen = true;
-    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true }));
     await elementUpdated(el);
 
-    expect(el.dropdown.isPopoverVisible).to.be.false;
+    expect(el.dropdown.isPopoverVisible).to.be.true;
   });
 });
+

--- a/components/counter/test/auro-counter-group.test.js
+++ b/components/counter/test/auro-counter-group.test.js
@@ -345,20 +345,6 @@ describe('auro-counter-group: keyboard navigation', () => {
     expect(el.dropdown.isPopoverVisible).to.be.false;
   });
 
-  it('sets nativeFocusableContent on bibContent when dropdown is toggled', async () => {
-    const el = await fixture(html`
-      <auro-counter-group isDropdown>
-        <auro-counter value="2">Counter 1</auro-counter>
-        <auro-counter value="3">Counter 2</auro-counter>
-      </auro-counter-group>
-    `);
-
-    el.dropdown.show();
-    await elementUpdated(el);
-
-    expect(el.dropdown.bibContent.nativeFocusableContent).to.be.true;
-  });
-
   it('does not close dropdown when Tab is pressed while bib is open', async () => {
     const el = await fixture(html`
       <auro-counter-group isDropdown>

--- a/components/menu/stories/component.stories.ts
+++ b/components/menu/stories/component.stories.ts
@@ -21,8 +21,8 @@ export default meta;
 
 type Story = StoryObj;
 
-// ─── ArrowDown activates first option ────────────────────────────────────────
-export const MenuArrowDownActivatesOption: Story = {
+// ─── navigateOptions('down') activates first option ────────────────────────────────────────
+export const MenuNavigateDownActivatesOption: Story = {
   tags: ['!autodocs', 'chromatic-enabled'],
   render: () => html`
 <auro-menu>
@@ -34,15 +34,15 @@ export const MenuArrowDownActivatesOption: Story = {
   async play({ canvasElement }: { canvasElement: HTMLElement }) {
     const el = canvasElement.querySelector('auro-menu') as any;
     const options = [...canvasElement.querySelectorAll('auro-menuoption')] as HTMLElement[];
-    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, composed: true }));
+    el.navigateOptions('down');
     await el.updateComplete;
     await expect(el.optionActive).toBe(options[0]);
     await expect(options[0].classList.contains('active')).toBe(true);
   },
 };
 
-// ─── ArrowDown wraps from last back to first ──────────────────────────────────
-export const MenuArrowDownWraps: Story = {
+// ─── navigateOptions('down') wraps from last back to first ──────────────────────────────────
+export const MenuNavigateDownWraps: Story = {
   tags: ['!autodocs', 'chromatic-enabled'],
   render: () => html`
 <auro-menu>
@@ -56,15 +56,15 @@ export const MenuArrowDownWraps: Story = {
     const options = [...canvasElement.querySelectorAll('auro-menuoption')] as HTMLElement[];
     // options.length + 1 downs wraps back to first option
     for (let i = 0; i < options.length + 1; i++) {
-      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, composed: true }));
+      el.navigateOptions('down');
       await el.updateComplete;
     }
     await expect(el.optionActive).toBe(options[0]);
   },
 };
 
-// ─── ArrowUp wraps from top to last option ────────────────────────────────────
-export const MenuArrowUpWraps: Story = {
+// ─── navigateOptions('up') wraps from top to last option ────────────────────────────────────
+export const MenuNavigateUpWraps: Story = {
   tags: ['!autodocs', 'chromatic-enabled'],
   render: () => html`
 <auro-menu>
@@ -76,14 +76,14 @@ export const MenuArrowUpWraps: Story = {
   async play({ canvasElement }: { canvasElement: HTMLElement }) {
     const el = canvasElement.querySelector('auro-menu') as any;
     const options = [...canvasElement.querySelectorAll('auro-menuoption')] as HTMLElement[];
-    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true, composed: true }));
+    el.navigateOptions('up');
     await el.updateComplete;
     await expect(el.optionActive).toBe(options[options.length - 1]);
   },
 };
 
-// ─── Enter selects the highlighted option ────────────────────────────────────
-export const MenuEnterSelectsOption: Story = {
+// ─── makeSelection selects the highlighted option ────────────────────────────────────
+export const MenuMakeSelectionSelectsOption: Story = {
   tags: ['!autodocs', 'chromatic-enabled'],
   render: () => html`
 <auro-menu>
@@ -95,17 +95,17 @@ export const MenuEnterSelectsOption: Story = {
   async play({ canvasElement }: { canvasElement: HTMLElement }) {
     const el = canvasElement.querySelector('auro-menu') as any;
     const options = [...canvasElement.querySelectorAll('auro-menuoption')] as HTMLElement[];
-    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, composed: true }));
+    el.navigateOptions('down');
     await el.updateComplete;
-    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, composed: true }));
+    el.makeSelection();
     await el.updateComplete;
     await expect(options[0].hasAttribute('selected')).toBe(true);
     await expect(el.optionSelected).toBe(options[0]);
   },
 };
 
-// ─── ArrowDown skips disabled and hidden options ──────────────────────────────
-export const MenuArrowDownSkipsDisabled: Story = {
+// ─── navigateOptions('down') skips disabled and hidden options ──────────────────────────────
+export const MenuNavigateDownSkipsDisabled: Story = {
   tags: ['!autodocs', 'chromatic-enabled'],
   render: () => html`
 <auro-menu>
@@ -118,15 +118,15 @@ export const MenuArrowDownSkipsDisabled: Story = {
   async play({ canvasElement }: { canvasElement: HTMLElement }) {
     const el = canvasElement.querySelector('auro-menu') as any;
     const options = [...canvasElement.querySelectorAll('auro-menuoption')] as HTMLElement[];
-    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, composed: true }));
+    el.navigateOptions('down');
     await el.updateComplete;
     // disabled options[0] and hidden options[1] should be skipped; land on options[2]
     await expect(el.optionActive).toBe(options[2]);
   },
 };
 
-// ─── Click selects the clicked option ────────────────────────────────────────
-export const MenuClickSelectsOption: Story = {
+// ─── navigateOptions + makeSelection selects the option ────────────────────────────────────
+export const MenuNavigateThenMakeSelection: Story = {
   tags: ['!autodocs', 'chromatic-enabled'],
   render: () => html`
 <auro-menu>
@@ -138,13 +138,11 @@ export const MenuClickSelectsOption: Story = {
   async play({ canvasElement }: { canvasElement: HTMLElement }) {
     const el = canvasElement.querySelector('auro-menu') as any;
     const options = [...canvasElement.querySelectorAll('auro-menuoption')] as HTMLElement[];
-    // Navigate to options[1] then select via Enter — the same path unit tests use,
-    // which reliably triggers the full menuService selection pipeline.
-    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, composed: true }));
+    el.navigateOptions('down');
     await el.updateComplete;
-    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, composed: true }));
+    el.navigateOptions('down');
     await el.updateComplete;
-    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, composed: true }));
+    el.makeSelection();
     await el.updateComplete;
     await expect(el.optionSelected).toBe(options[1]);
     await expect(options[1].hasAttribute('selected')).toBe(true);

--- a/components/menu/test/auro-menu.test.js
+++ b/components/menu/test/auro-menu.test.js
@@ -17,26 +17,18 @@ describe('auro-menu', () => {
     await expect(el).to.be.accessible();
   });
 
-  it('Enter keyboardEvent marks option as selected', async () => {
+  it('makeSelection marks option as selected', async () => {
     const el = await defaultFixture();
     const menuEl = el.querySelector('auro-menu');
     const options = getOptions(menuEl);
     const index = 0;
 
     // Navigate to first option
-    menuEl.dispatchEvent(new KeyboardEvent('keydown', {
-      bubbles: true,
-      composed: true,
-      'key': 'ArrowDown'
-    }));
+    menuEl.navigateOptions('down');
     await elementUpdated(menuEl);
 
-    // Select with Enter
-    menuEl.dispatchEvent(new KeyboardEvent('keydown', {
-      bubbles: true,
-      composed: true,
-      'key': 'Enter'
-    }));
+    // Select active option
+    menuEl.makeSelection();
     await elementUpdated(menuEl);
 
     // Verify selection
@@ -45,33 +37,21 @@ describe('auro-menu', () => {
     expect(menuEl.optionSelected).to.equal(options[index]);
   });
 
-  it('Enter ArrowDown marks option as selected', async () => {
+  it('navigate down then makeSelection marks option as selected', async () => {
     const el = await defaultFixture();
     const menuEl = el.querySelector('auro-menu');
     const options = getOptions(menuEl);
 
     // Navigate down
-    menuEl.dispatchEvent(new KeyboardEvent('keydown', {
-      bubbles: true,
-      composed: true,
-      'key': 'ArrowDown'
-    }));
+    menuEl.navigateOptions('down');
     await elementUpdated(menuEl);
 
     // Another down to get to second option
-    menuEl.dispatchEvent(new KeyboardEvent('keydown', {
-      bubbles: true,
-      composed: true,
-      'key': 'ArrowDown'
-    }));
+    menuEl.navigateOptions('down');
     await elementUpdated(menuEl);
 
-    // Select with Enter
-    menuEl.dispatchEvent(new KeyboardEvent('keydown', {
-      bubbles: true,
-      composed: true,
-      'key': 'Enter'
-    }));
+    // Select active option
+    menuEl.makeSelection();
     await elementUpdated(menuEl);
 
     expect(menuEl.optionSelected).to.equal(options[1]);
@@ -84,11 +64,7 @@ describe('auro-menu', () => {
 
     // Press down repeatedly to reach last option
     for (let i = 0; i < options.length + 1; i++) {
-      menuEl.dispatchEvent(new KeyboardEvent('keydown', {
-        bubbles: true,
-        composed: true,
-        'key': 'ArrowDown'
-      }));
+      menuEl.navigateOptions('down');
       await elementUpdated(menuEl);
     }
 
@@ -103,35 +79,23 @@ describe('auro-menu', () => {
     const lastIndex = options.length - 1;
 
     // Then move up to trigger wrapping behavior
-    menuEl.dispatchEvent(new KeyboardEvent('keydown', {
-      bubbles: true,
-      composed: true,
-      'key': 'ArrowUp'
-    }));
+    menuEl.navigateOptions('up');
     await elementUpdated(menuEl);
 
     expect(menuEl.optionActive).to.equal(options[lastIndex]);
   });
 
-  it('Enter ArrowUp marks option as active', async () => {
+  it('navigate down then up marks option as active', async () => {
     const el = await defaultFixture();
     const menuEl = el.querySelector('auro-menu');
     const options = getOptions(menuEl);
 
     // Initialize state by moving down first
-    menuEl.dispatchEvent(new KeyboardEvent('keydown', {
-      bubbles: true,
-      composed: true,
-      'key': 'ArrowDown'
-    }));
+    menuEl.navigateOptions('down');
     await elementUpdated(menuEl);
 
     // Move up
-    menuEl.dispatchEvent(new KeyboardEvent('keydown', {
-      bubbles: true,
-      composed: true,
-      'key': 'ArrowUp'
-    }));
+    menuEl.navigateOptions('up');
     await elementUpdated(menuEl);
 
     const selectedOption = options.find(opt => opt.classList.contains('active'));
@@ -144,11 +108,7 @@ describe('auro-menu', () => {
     const options = getOptions(menuEl);
 
     // Navigate down - should skip disabled and hidden options
-    menuEl.dispatchEvent(new KeyboardEvent('keydown', {
-      bubbles: true,
-      composed: true,
-      'key': 'ArrowDown'
-    }));
+    menuEl.navigateOptions('down');
     await elementUpdated(menuEl);
 
     // Should have skipped to option 3 (index 2) since first two are non-interactive
@@ -192,18 +152,10 @@ describe('auro-menu', () => {
   it('test empty items handler', async () => {
     const el = await emptyItemsFixture();
     const menuEl = el.querySelector('auro-menu');
-    menuEl.dispatchEvent(new KeyboardEvent('keydown', {
-      bubbles: true,
-      composed: true,
-      'key': 'Enter'
-    }));
+    menuEl.makeSelection();
 
     const menuChild = menuEl.querySelector('[test-id=test-child]');
-    menuChild.dispatchEvent(new KeyboardEvent('keydown', {
-      bubbles: true,
-      composed: true,
-      'key': 'Enter'
-    }));
+    menuChild.makeSelection();
 
     expect(menuEl.items).to.equal(undefined);
     expect(menuChild.items).to.equal(undefined);
@@ -263,33 +215,17 @@ describe('multiSelect', () => {
     const options = getOptions(menuEl);
 
     // Select first option
-    menuEl.dispatchEvent(new KeyboardEvent('keydown', {
-      bubbles: true,
-      composed: true,
-      'key': 'ArrowDown'
-    }));
+    menuEl.navigateOptions('down');
     await elementUpdated(menuEl);
 
-    menuEl.dispatchEvent(new KeyboardEvent('keydown', {
-      bubbles: true,
-      composed: true,
-      'key': 'Enter'
-    }));
+    menuEl.makeSelection();
     await elementUpdated(menuEl);
 
     // Select second option
-    menuEl.dispatchEvent(new KeyboardEvent('keydown', {
-      bubbles: true,
-      composed: true,
-      'key': 'ArrowDown'
-    }));
+    menuEl.navigateOptions('down');
     await elementUpdated(menuEl);
 
-    menuEl.dispatchEvent(new KeyboardEvent('keydown', {
-      bubbles: true,
-      composed: true,
-      'key': 'Enter'
-    }));
+    menuEl.makeSelection();
     await elementUpdated(menuEl);
 
     // Verify both options are selected
@@ -522,48 +458,24 @@ describe('multiSelect', () => {
     const options = getOptions(menuEl);
 
     // Select first option
-    menuEl.dispatchEvent(new KeyboardEvent('keydown', {
-      bubbles: true,
-      composed: true,
-      'key': 'ArrowDown'
-    }));
+    menuEl.navigateOptions('down');
     await elementUpdated(menuEl);
 
-    menuEl.dispatchEvent(new KeyboardEvent('keydown', {
-      bubbles: true,
-      composed: true,
-      'key': 'Enter'
-    }));
+    menuEl.makeSelection();
     await elementUpdated(menuEl);
 
     // Select second option
-    menuEl.dispatchEvent(new KeyboardEvent('keydown', {
-      bubbles: true,
-      composed: true,
-      'key': 'ArrowDown'
-    }));
+    menuEl.navigateOptions('down');
     await elementUpdated(menuEl);
 
-    menuEl.dispatchEvent(new KeyboardEvent('keydown', {
-      bubbles: true,
-      composed: true,
-      'key': 'Enter'
-    }));
+    menuEl.makeSelection();
     await elementUpdated(menuEl);
 
     // Deselect first option
-    menuEl.dispatchEvent(new KeyboardEvent('keydown', {
-      bubbles: true,
-      composed: true,
-      'key': 'ArrowUp'
-    }));
+    menuEl.navigateOptions('up');
     await elementUpdated(menuEl);
 
-    menuEl.dispatchEvent(new KeyboardEvent('keydown', {
-      bubbles: true,
-      composed: true,
-      'key': 'Enter'
-    }));
+    menuEl.makeSelection();
     await elementUpdated(menuEl);
 
     // Verify only second option remains selected
@@ -579,40 +491,20 @@ describe('multiSelect', () => {
     const options = getOptions(menuEl);
 
     // Select first option
-    menuEl.dispatchEvent(new KeyboardEvent('keydown', {
-      bubbles: true,
-      composed: true,
-      'key': 'ArrowDown'
-    }));
+    menuEl.navigateOptions('down');
     await elementUpdated(menuEl);
 
-    menuEl.dispatchEvent(new KeyboardEvent('keydown', {
-      bubbles: true,
-      composed: true,
-      'key': 'Enter'
-    }));
+    menuEl.makeSelection();
     await elementUpdated(menuEl);
 
     // Select third option
-    menuEl.dispatchEvent(new KeyboardEvent('keydown', {
-      bubbles: true,
-      composed: true,
-      'key': 'ArrowDown'
-    }));
+    menuEl.navigateOptions('down');
     await elementUpdated(menuEl);
 
-    menuEl.dispatchEvent(new KeyboardEvent('keydown', {
-      bubbles: true,
-      composed: true,
-      'key': 'ArrowDown'
-    }));
+    menuEl.navigateOptions('down');
     await elementUpdated(menuEl);
 
-    menuEl.dispatchEvent(new KeyboardEvent('keydown', {
-      bubbles: true,
-      composed: true,
-      'key': 'Enter'
-    }));
+    menuEl.makeSelection();
     await elementUpdated(menuEl);
 
     // Verify aria-selected states
@@ -708,7 +600,7 @@ describe('value states', () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(menu.value).to.equal('option 2');
-    expect(menu.optionSelected?.value).to.equal('option 2');
+    expect(menu.optionSelected && menu.optionSelected.value).to.equal('option 2');
     expect(selectedEventCount).to.equal(1);
   });
 
@@ -718,29 +610,17 @@ describe('value states', () => {
     const menu = el.querySelector('auro-menu');
 
     // Select first option
-    menu.dispatchEvent(new KeyboardEvent('keydown', {
-      bubbles: true,
-      composed: true,
-      'key': 'ArrowDown'
-    }));
+    menu.navigateOptions('down');
     await elementUpdated(menu);
 
-    menu.dispatchEvent(new KeyboardEvent('keydown', {
-      bubbles: true,
-      composed: true,
-      'key': 'Enter'
-    }));
+    menu.makeSelection();
     await elementUpdated(menu);
 
     // Verify selection results in array
     expect(menu.value).to.eql('option 1');
 
     // Try to deselect by clicking again
-    menu.dispatchEvent(new KeyboardEvent('keydown', {
-      bubbles: true,
-      composed: true,
-      'key': 'Enter'
-    }));
+    menu.makeSelection();
     await elementUpdated(menu);
 
     // Selection should persist
@@ -760,16 +640,8 @@ describe('value states', () => {
     expect(menu.value).to.eql('option 1');
 
     // Deselect by clicking again
-    menu.dispatchEvent(new KeyboardEvent('keydown', {
-      bubbles: true,
-      composed: true,
-      'key': 'ArrowDown'
-    }));
-    menu.dispatchEvent(new KeyboardEvent('keydown', {
-      bubbles: true,
-      composed: true,
-      'key': 'Enter'
-    }));
+    menu.navigateOptions('down');
+    menu.makeSelection();
     await elementUpdated(menu);
 
     // Should be undefined after deselection
@@ -787,18 +659,10 @@ describe('value states', () => {
     expect(menu.optionSelected).to.equal(undefined);
 
     // Select an option
-    menu.dispatchEvent(new KeyboardEvent('keydown', {
-      bubbles: true,
-      composed: true,
-      'key': 'ArrowDown'
-    }));
+    menu.navigateOptions('down');
     await elementUpdated(menu);
 
-    menu.dispatchEvent(new KeyboardEvent('keydown', {
-      bubbles: true,
-      composed: true,
-      'key': 'Enter'
-    }));
+    menu.makeSelection();
     await elementUpdated(menu);
 
     // Verify selection
@@ -822,29 +686,17 @@ describe('value states', () => {
     expect(menu.optionSelected).to.equal(undefined);
 
     // Select and verify
-    menu.dispatchEvent(new KeyboardEvent('keydown', {
-      bubbles: true,
-      composed: true,
-      'key': 'ArrowDown'
-    }));
+    menu.navigateOptions('down');
     await elementUpdated(menu);
 
-    menu.dispatchEvent(new KeyboardEvent('keydown', {
-      bubbles: true,
-      composed: true,
-      'key': 'Enter'
-    }));
+    menu.makeSelection();
     await elementUpdated(menu);
 
     // Verify array after selection
     expect(menu.value).to.eql('option 1');
 
     // Try to deselect - should have no effect
-    menu.dispatchEvent(new KeyboardEvent('keydown', {
-      bubbles: true,
-      composed: true,
-      'key': 'Enter'
-    }));
+    menu.makeSelection();
     await elementUpdated(menu);
 
     // Selection should persist
@@ -867,18 +719,10 @@ describe('value states', () => {
     expect(menu.value).to.equal(undefined);
 
     // Select in multiselect
-    menu.dispatchEvent(new KeyboardEvent('keydown', {
-      bubbles: true,
-      composed: true,
-      'key': 'ArrowDown'
-    }));
+    menu.navigateOptions('down');
     await elementUpdated(menu);
 
-    menu.dispatchEvent(new KeyboardEvent('keydown', {
-      bubbles: true,
-      composed: true,
-      'key': 'Enter'
-    }));
+    menu.makeSelection();
     await elementUpdated(menu);
 
     // After selection, should be array
@@ -887,11 +731,7 @@ describe('value states', () => {
     expect(jsonValue).to.eql(['option1']);
 
     // Deselect
-    menu.dispatchEvent(new KeyboardEvent('keydown', {
-      bubbles: true,
-      composed: true,
-      'key': 'Enter'
-    }));
+    menu.makeSelection();
     await elementUpdated(menu);
 
     // After deselection, should be undefined
@@ -942,18 +782,10 @@ describe('multiSelect initial state', () => {
     const menuEl = el.querySelector('auro-menu');
 
     // Navigate without selecting
-    menuEl.dispatchEvent(new KeyboardEvent('keydown', {
-      bubbles: true,
-      composed: true,
-      'key': 'ArrowDown'
-    }));
+    menuEl.navigateOptions('down');
     await elementUpdated(menuEl);
 
-    menuEl.dispatchEvent(new KeyboardEvent('keydown', {
-      bubbles: true,
-      composed: true,
-      'key': 'ArrowDown'
-    }));
+    menuEl.navigateOptions('down');
     await elementUpdated(menuEl);
 
     // Verify value remains undefined
@@ -961,11 +793,7 @@ describe('multiSelect initial state', () => {
     expect(menuEl.optionSelected).to.equal(undefined);
 
     // Make first selection
-    menuEl.dispatchEvent(new KeyboardEvent('keydown', {
-      bubbles: true,
-      composed: true,
-      'key': 'Enter'
-    }));
+    menuEl.makeSelection();
     await elementUpdated(menuEl);
 
     // Verify value is now an array
@@ -1045,11 +873,11 @@ describe('nested menu: arrow key navigation', () => {
     const nestedOptions = [...nestedMenu.querySelectorAll('auro-menuoption')];
 
     // First ArrowDown → highlights option 1 (root)
-    rootMenu.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, composed: true, key: 'ArrowDown' }));
+    rootMenu.navigateOptions('down');
     await elementUpdated(rootMenu);
 
     // Second ArrowDown → highlights option a (first nested option)
-    rootMenu.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, composed: true, key: 'ArrowDown' }));
+    rootMenu.navigateOptions('down');
     await elementUpdated(rootMenu);
 
     expect(rootMenu.optionActive).to.equal(nestedOptions[0]);
@@ -1062,7 +890,7 @@ describe('nested menu: arrow key navigation', () => {
 
     // Navigate to option 1 → option a → option b → option 2
     for (let i = 0; i < 4; i++) {
-      rootMenu.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, composed: true, key: 'ArrowDown' }));
+      rootMenu.navigateOptions('down');
       await elementUpdated(rootMenu);
     }
 
@@ -1075,13 +903,13 @@ describe('nested menu: arrow key navigation', () => {
     const rootOptions = [...el.querySelectorAll(':scope > auro-menu > auro-menuoption')];
 
     // Navigate down to the first nested option (option a)
-    rootMenu.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, composed: true, key: 'ArrowDown' }));
+    rootMenu.navigateOptions('down');
     await elementUpdated(rootMenu);
-    rootMenu.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, composed: true, key: 'ArrowDown' }));
+    rootMenu.navigateOptions('down');
     await elementUpdated(rootMenu);
 
     // ArrowUp should go back to option 1 (root)
-    rootMenu.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, composed: true, key: 'ArrowUp' }));
+    rootMenu.navigateOptions('up');
     await elementUpdated(rootMenu);
 
     expect(rootMenu.optionActive).to.equal(rootOptions[0]);
@@ -1093,26 +921,26 @@ describe('nested menu: arrow key navigation', () => {
     const allOptions = [...el.querySelectorAll('auro-menuoption')];
 
     // ArrowUp with no active option wraps to the last option
-    rootMenu.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, composed: true, key: 'ArrowUp' }));
+    rootMenu.navigateOptions('up');
     await elementUpdated(rootMenu);
 
     expect(rootMenu.optionActive).to.equal(allOptions[allOptions.length - 1]);
   });
 
-  it('Enter selects a nested option', async () => {
+  it('makeSelection selects a nested option', async () => {
     const el = await nestedMenuFixture();
     const rootMenu = el.querySelector('auro-menu');
     const nestedMenu = el.querySelector('auro-menu auro-menu');
     const nestedOptions = [...nestedMenu.querySelectorAll('auro-menuoption')];
 
     // Navigate to first nested option (option a)
-    rootMenu.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, composed: true, key: 'ArrowDown' }));
+    rootMenu.navigateOptions('down');
     await elementUpdated(rootMenu);
-    rootMenu.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, composed: true, key: 'ArrowDown' }));
+    rootMenu.navigateOptions('down');
     await elementUpdated(rootMenu);
 
     // Select it
-    rootMenu.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, composed: true, key: 'Enter' }));
+    rootMenu.makeSelection();
     await elementUpdated(rootMenu);
 
     expect(rootMenu.optionSelected).to.equal(nestedOptions[0]);

--- a/context/keyboard-spec.md
+++ b/context/keyboard-spec.md
@@ -33,9 +33,7 @@ All four components listen for the `auroDropdown-toggled` event (or equivalent v
 
 ### Tab Closes Fullscreen Dialog
 
-In addition to initial focus, select, combobox, and datepicker close the fullscreen dialog when Tab is pressed. Select and combobox handle this in their keyboard strategy files. Datepicker uses a direct `keydown` listener that checks `evt.key === 'Tab' && dropdown.isPopoverVisible && dropdown.isBibFullscreen` before calling `dropdown.hide()`. The dialog event bridge re-dispatches Tab from inside the modal so it reaches these listeners.
-
-Counter-group is the exception — see [Native Focusable Content](#native-focusable-content-nativefocusablecontent) below.
+In addition to initial focus, all four components close the fullscreen dialog when Tab is pressed. Select and combobox handle this in their keyboard strategy files. Datepicker and counter-group use a direct `keydown` listener that checks `evt.key === 'Tab' && dropdown.isPopoverVisible && dropdown.isBibFullscreen` before calling `dropdown.hide()`. The dialog event bridge re-dispatches Tab from inside the modal so it reaches these listeners.
 
 ---
 
@@ -181,27 +179,6 @@ The trade-off: intercepted keys must have their native behaviors manually re-imp
 - **Tab:** `preventDefault()` stops native Tab cycling inside the dialog. The re-dispatched Tab reaches the component strategy, which runs select-and-close logic. The dialog's native Tab trap only cycles between the close button and browser chrome — not useful for listbox navigation.
 - **Escape:** The native `<dialog>` fires a `cancel` event on `Escape` key (handled separately). The re-dispatched `Escape` is a secondary path for parent components that also listen for `Escape` keydown.
 
-#### Native Focusable Content (`nativeFocusableContent`)
-
-The bridge's blanket `preventDefault()` + `stopPropagation()` on Tab assumed all bib consumers use a listbox navigated via `aria-activedescendant`, where nothing inside is directly focusable and Tab means "select + close." This assumption is incorrect for `auro-counter-group`, whose bib contains real focusable elements (increment/decrement buttons on each counter) that need native Tab navigation.
-
-The `nativeFocusableContent` boolean property on `AuroDropdownBib` solves this. When `true`, the bridge skips Tab interception entirely — `preventDefault()` and `stopPropagation()` are not called, and the native Tab event proceeds normally. This allows:
-
-- **Desktop:** The `FocusTrap` (created by `auro-dropdown`) manages Tab wrap-around between the focusable counter elements inside the bib.
-- **Fullscreen:** The `<dialog>`'s native focus trap (from `showModal()`) keeps Tab cycling within the dialog's focusable content.
-
-**How it's set:** The consumer component sets the property on the bib element during configuration. Counter-group sets it in `configureBibtemplate()`:
-
-```js
-if (this.dropdown.bibContent) {
-  this.dropdown.bibContent.nativeFocusableContent = true;
-}
-```
-
-**Effect on other keys:** Only Tab is affected. Arrow keys, Enter, and Escape continue to be intercepted and re-dispatched as before, regardless of `nativeFocusableContent`. Counter doesn't need these keys bridged — its buttons handle clicks natively and there is no listbox or `aria-activedescendant` navigation.
-
-**When to use:** Set `nativeFocusableContent = true` on any bib consumer whose content contains real focusable elements that need native Tab navigation. Do not set it for listbox-based consumers (select, combobox) where Tab means "select + close."
-
 ---
 
 ## Keyboard Interactions
@@ -261,25 +238,6 @@ Same arrow key, Enter, and Escape behavior as select. Tab behavior differs becau
 | **Tab** (focus on clear button, no option highlighted) | Closes the dialog, returns focus to trigger | Design decision | Tabbing past the last focusable element closes the dialog |
 | **Tab** (no clear button / no value) | Closes the dialog, returns focus to trigger | Design decision | Same as select behavior |
 | **Shift+Tab** | Moves visual focus to first non-disabled option, keeps dialog open, no selection | Design decision | Available regardless of clear button state; bridge re-dispatches Shift+Tab with `shiftKey` preserved |
-
-### Fullscreen (Mobile) — Counter Dialog Open
-
-Unlike select and combobox, the counter dialog contains **real focusable elements** — increment and decrement buttons on each counter. There is no listbox or `aria-activedescendant` navigation. The `nativeFocusableContent` flag on the bib tells the keyboard bridge to skip Tab interception, so native Tab behavior is preserved.
-
-| Key | Behavior | Spec Basis | Notes |
-|---|---|---|---|
-| **Tab** | Moves focus to next focusable element in the dialog (close button, counter buttons) | Native `<dialog>` focus trap | Bridge does not intercept Tab due to `nativeFocusableContent` |
-| **Shift+Tab** | Moves focus to previous focusable element in the dialog | Native `<dialog>` focus trap | Same as above |
-| **Escape** | Closes the dialog, returns focus to trigger | Native `<dialog>` `cancel` event | Handled by `_setupCancelHandler` |
-| **Enter** | Clicks the focused button (close, increment, or decrement) | Bridge Enter→click on buttons | Bridge still intercepts Enter for custom element click behavior |
-
-### Desktop — Counter Popup Open
-
-| Key | Behavior | Notes |
-|---|---|---|
-| **Tab** | Moves focus to next focusable counter element; wraps around at ends | `FocusTrap` manages wrap-around |
-| **Shift+Tab** | Moves focus to previous focusable counter element; wraps around at ends | `FocusTrap` manages wrap-around |
-| **Escape** | Closes the popup, returns focus to trigger | Re-dispatched by bridge |
 
 ---
 
@@ -365,12 +323,12 @@ These are defined in the APG combobox pattern for popup-open state. They are not
 
 ## Components Affected
 
-| Component | Strategy File | Tab Handler | `nativeFocusableContent` | Effect |
-|---|---|---|---|---|
-| `auro-select` | `selectKeyboardStrategy.js` | Yes (strategy) | `false` (default) | Selects active option + closes |
-| `auro-combobox` | `comboboxKeyboardStrategy.js` | Yes (strategy) | `false` (default) | Input → clear button → closes |
-| `auro-datepicker` | None | Yes (direct listener) | `false` (default) | Closes fullscreen dialog |
-| `auro-counter-group` | None | Native Tab | `true` | Tab moves focus between counters in bib |
+| Component | Strategy File | Tab Handler | Effect |
+|---|---|---|---|
+| `auro-select` | `selectKeyboardStrategy.js` | Yes (strategy) | Selects active option + closes |
+| `auro-combobox` | `comboboxKeyboardStrategy.js` | Yes (strategy) | Input → clear button → closes |
+| `auro-datepicker` | None | Yes (direct listener) | Closes fullscreen dialog |
+| `auro-counter-group` | None | Yes (direct listener) | Closes fullscreen dialog |
 
 ---
 

--- a/context/keyboard-spec.md
+++ b/context/keyboard-spec.md
@@ -33,7 +33,9 @@ All four components listen for the `auroDropdown-toggled` event (or equivalent v
 
 ### Tab Closes Fullscreen Dialog
 
-In addition to initial focus, all four components close the fullscreen dialog when Tab is pressed. Select and combobox handle this in their keyboard strategy files. Datepicker and counter-group use a direct `keydown` listener that checks `evt.key === 'Tab' && dropdown.isPopoverVisible && dropdown.isBibFullscreen` before calling `dropdown.hide()`. The dialog event bridge re-dispatches Tab from inside the modal so it reaches these listeners.
+In addition to initial focus, select, combobox, and datepicker close the fullscreen dialog when Tab is pressed. Select and combobox handle this in their keyboard strategy files. Datepicker uses a direct `keydown` listener that checks `evt.key === 'Tab' && dropdown.isPopoverVisible && dropdown.isBibFullscreen` before calling `dropdown.hide()`. The dialog event bridge re-dispatches Tab from inside the modal so it reaches these listeners.
+
+Counter-group is the exception — see [Native Focusable Content](#native-focusable-content-nativefocusablecontent) below.
 
 ---
 
@@ -179,6 +181,27 @@ The trade-off: intercepted keys must have their native behaviors manually re-imp
 - **Tab:** `preventDefault()` stops native Tab cycling inside the dialog. The re-dispatched Tab reaches the component strategy, which runs select-and-close logic. The dialog's native Tab trap only cycles between the close button and browser chrome — not useful for listbox navigation.
 - **Escape:** The native `<dialog>` fires a `cancel` event on `Escape` key (handled separately). The re-dispatched `Escape` is a secondary path for parent components that also listen for `Escape` keydown.
 
+#### Native Focusable Content (`nativeFocusableContent`)
+
+The bridge's blanket `preventDefault()` + `stopPropagation()` on Tab assumed all bib consumers use a listbox navigated via `aria-activedescendant`, where nothing inside is directly focusable and Tab means "select + close." This assumption is incorrect for `auro-counter-group`, whose bib contains real focusable elements (increment/decrement buttons on each counter) that need native Tab navigation.
+
+The `nativeFocusableContent` boolean property on `AuroDropdownBib` solves this. When `true`, the bridge skips Tab interception entirely — `preventDefault()` and `stopPropagation()` are not called, and the native Tab event proceeds normally. This allows:
+
+- **Desktop:** The `FocusTrap` (created by `auro-dropdown`) manages Tab wrap-around between the focusable counter elements inside the bib.
+- **Fullscreen:** The `<dialog>`'s native focus trap (from `showModal()`) keeps Tab cycling within the dialog's focusable content.
+
+**How it's set:** The consumer component sets the property on the bib element during configuration. Counter-group sets it in `configureBibtemplate()`:
+
+```js
+if (this.dropdown.bibContent) {
+  this.dropdown.bibContent.nativeFocusableContent = true;
+}
+```
+
+**Effect on other keys:** Only Tab is affected. Arrow keys, Enter, and Escape continue to be intercepted and re-dispatched as before, regardless of `nativeFocusableContent`. Counter doesn't need these keys bridged — its buttons handle clicks natively and there is no listbox or `aria-activedescendant` navigation.
+
+**When to use:** Set `nativeFocusableContent = true` on any bib consumer whose content contains real focusable elements that need native Tab navigation. Do not set it for listbox-based consumers (select, combobox) where Tab means "select + close."
+
 ---
 
 ## Keyboard Interactions
@@ -238,6 +261,25 @@ Same arrow key, Enter, and Escape behavior as select. Tab behavior differs becau
 | **Tab** (focus on clear button, no option highlighted) | Closes the dialog, returns focus to trigger | Design decision | Tabbing past the last focusable element closes the dialog |
 | **Tab** (no clear button / no value) | Closes the dialog, returns focus to trigger | Design decision | Same as select behavior |
 | **Shift+Tab** | Moves visual focus to first non-disabled option, keeps dialog open, no selection | Design decision | Available regardless of clear button state; bridge re-dispatches Shift+Tab with `shiftKey` preserved |
+
+### Fullscreen (Mobile) — Counter Dialog Open
+
+Unlike select and combobox, the counter dialog contains **real focusable elements** — increment and decrement buttons on each counter. There is no listbox or `aria-activedescendant` navigation. The `nativeFocusableContent` flag on the bib tells the keyboard bridge to skip Tab interception, so native Tab behavior is preserved.
+
+| Key | Behavior | Spec Basis | Notes |
+|---|---|---|---|
+| **Tab** | Moves focus to next focusable element in the dialog (close button, counter buttons) | Native `<dialog>` focus trap | Bridge does not intercept Tab due to `nativeFocusableContent` |
+| **Shift+Tab** | Moves focus to previous focusable element in the dialog | Native `<dialog>` focus trap | Same as above |
+| **Escape** | Closes the dialog, returns focus to trigger | Native `<dialog>` `cancel` event | Handled by `_setupCancelHandler` |
+| **Enter** | Clicks the focused button (close, increment, or decrement) | Bridge Enter→click on buttons | Bridge still intercepts Enter for custom element click behavior |
+
+### Desktop — Counter Popup Open
+
+| Key | Behavior | Notes |
+|---|---|---|
+| **Tab** | Moves focus to next focusable counter element; wraps around at ends | `FocusTrap` manages wrap-around |
+| **Shift+Tab** | Moves focus to previous focusable counter element; wraps around at ends | `FocusTrap` manages wrap-around |
+| **Escape** | Closes the popup, returns focus to trigger | Re-dispatched by bridge |
 
 ---
 
@@ -323,12 +365,12 @@ These are defined in the APG combobox pattern for popup-open state. They are not
 
 ## Components Affected
 
-| Component | Strategy File | Tab Handler | Effect |
-|---|---|---|---|
-| `auro-select` | `selectKeyboardStrategy.js` | Yes (strategy) | Selects active option + closes |
-| `auro-combobox` | `comboboxKeyboardStrategy.js` | Yes (strategy) | Input → clear button → closes |
-| `auro-datepicker` | None | Yes (direct listener) | Closes fullscreen dialog |
-| `auro-counter-group` | None | Yes (direct listener) | Closes fullscreen dialog |
+| Component | Strategy File | Tab Handler | `nativeFocusableContent` | Effect |
+|---|---|---|---|---|
+| `auro-select` | `selectKeyboardStrategy.js` | Yes (strategy) | `false` (default) | Selects active option + closes |
+| `auro-combobox` | `comboboxKeyboardStrategy.js` | Yes (strategy) | `false` (default) | Input → clear button → closes |
+| `auro-datepicker` | None | Yes (direct listener) | `false` (default) | Closes fullscreen dialog |
+| `auro-counter-group` | None | Native Tab | `true` | Tab moves focus between counters in bib |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -68,8 +68,7 @@
     "test:framework:svelte": "turbo run test:framework --filter=@aurodesignsystem/svelte-framework",
     "test:frameworks": "turbo run test:framework --filter=@aurodesignsystem/react-framework --filter=@aurodesignsystem/svelte-framework",
     "test:framework:report:react": "npm run test:framework:report -w apps/react-framework",
-    "test:framework:report:svelte": "npm run test:framework:report -w apps/svelte-framework",
-    "test:frameworks:report": "rm -rf framework-blobs && mkdir framework-blobs; npm run test:framework:report -w apps/react-framework -- --reporter=blob; npm run test:framework:report -w apps/svelte-framework -- --reporter=blob; cp apps/react-framework/blob-report/*.zip framework-blobs/ 2>/dev/null; cp apps/svelte-framework/blob-report/*.zip framework-blobs/ 2>/dev/null; npx playwright merge-reports --reporter html framework-blobs && npx playwright show-report"
+    "test:framework:report:svelte": "npm run test:framework:report -w apps/svelte-framework"
   },
   "dependencies": {
     "@lit/context": "^1.1.6",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,10 @@
     "build-storybook": "npm run build && npm run analyze && storybook build",
     "test:framework:react": "turbo run test:framework --filter=@aurodesignsystem/react-framework",
     "test:framework:svelte": "turbo run test:framework --filter=@aurodesignsystem/svelte-framework",
-    "test:frameworks": "turbo run test:framework --filter=@aurodesignsystem/react-framework --filter=@aurodesignsystem/svelte-framework"
+    "test:frameworks": "turbo run test:framework --filter=@aurodesignsystem/react-framework --filter=@aurodesignsystem/svelte-framework",
+    "test:framework:report:react": "npm run test:framework:report -w apps/react-framework",
+    "test:framework:report:svelte": "npm run test:framework:report -w apps/svelte-framework",
+    "test:frameworks:report": "rm -rf framework-blobs && mkdir framework-blobs; npm run test:framework:report -w apps/react-framework -- --reporter=blob; npm run test:framework:report -w apps/svelte-framework -- --reporter=blob; cp apps/react-framework/blob-report/*.zip framework-blobs/ 2>/dev/null; cp apps/svelte-framework/blob-report/*.zip framework-blobs/ 2>/dev/null; npx playwright merge-reports --reporter html framework-blobs && npx playwright show-report"
   },
   "dependencies": {
     "@lit/context": "^1.1.6",


### PR DESCRIPTION
# Alaska Airlines Pull Request

enable native tab behavior for counter-group [AB#1516613](https://itsals.visualstudio.com/5e9f12eb-f830-406f-bee9-be25938f7aaa/_workitems/edit/1516613)

## Review Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Allow dropdown bibs used by counter groups to opt into native Tab key handling for focusable content and simplify fullscreen counter dialog keyboard behavior.

Bug Fixes:
- Restore native Tab navigation within focusable elements rendered inside dropdown bib content, such as counter controls in fullscreen mode.

Enhancements:
- Introduce a configurable flag on dropdown bib content to bypass the keyboard bridge’s Tab interception when hosting native focusable elements.
- Remove custom Tab key listener on counter group fullscreen dialog in favor of native Tab behavior provided by the dropdown bib.