### PR TITLE
Nested menu non-working draft

### DIFF
--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -753,6 +753,7 @@ export class AuroCombobox extends AuroElement {
       if (!this.dropdownOpen && this.input) {
         this.input.setActiveDescendant(null);
         this.optionActive = null;
+        this.menu.menuService.clearHighlight();
 
         // Remove the highlighted state from all menu options so re-opening
         // the dropdown doesn't show a stale highlight.

--- a/components/combobox/stories/component.stories.ts
+++ b/components/combobox/stories/component.stories.ts
@@ -430,7 +430,7 @@ async function waitUntil(predicate: () => boolean, timeout = 2000, interval = 20
 }
 
 export const ComboboxArrowKeysIgnoredWhenClearBtnFocused: Story = {
-  tags: ['!autodocs'],
+  tags: ['!autodocs', 'chromatic-enabled'],
   render: () => html`
 <auro-combobox>
   <span slot="ariaLabel.bib.close">Close combobox</span>
@@ -498,5 +498,338 @@ export const ComboboxArrowKeysIgnoredWhenClearBtnFocused: Story = {
     el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' }));
     await el.updateComplete;
     await expect(el.dropdown.isPopoverVisible).toBe(false);
+  },
+};
+
+// ─── Nested menu: ArrowDown reaches options inside a nested auro-menu ────────
+export const ComboboxNestedMenuKeyboardNav: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-combobox noFilter>
+  <span slot="label">Nested Menu</span>
+  <auro-menu>
+    <auro-menuoption value="stops">Stops</auro-menuoption>
+    <auro-menuoption value="price">Price</auro-menuoption>
+    <auro-menu>
+      <auro-menuoption value="apples">Apples</auro-menuoption>
+      <auro-menuoption value="oranges">Oranges</auro-menuoption>
+    </auro-menu>
+    <auro-menuoption value="departure">Departure</auro-menuoption>
+  </auro-menu>
+</auro-combobox>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-combobox') as any;
+    await el.updateComplete;
+
+    // Set a value so showBib() passes its input.value guard
+    setInputValue(el, 'a');
+    await new Promise((r) => setTimeout(r, 100));
+
+    // Open the bib via trigger click — same reliable pattern as ComboboxBibOpensOnType
+    const trigger = el.dropdown.querySelector('[slot="trigger"]') as HTMLElement;
+    trigger.click();
+    await new Promise((r) => setTimeout(r, 50));
+    await expect(el.dropdown.isPopoverVisible).toBe(true);
+
+    // Wait > 150 ms for the auroDropdown-toggled handler's `updateActiveOption(0)`
+    // setTimeout to fire and settle. That call snaps the highlight to stops 150 ms
+    // after the bib opens — navigating before it fires causes it to override the
+    // destination and revert to the first option.
+    await new Promise((r) => setTimeout(r, 200));
+
+    // ArrowDown twice: stops (already highlighted by updateActiveOption) → price → apples (nested).
+    // Three presses would overshoot to oranges since stops is pre-highlighted after the 200ms wait.
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    await el.updateComplete;
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    await el.updateComplete;
+
+    // Nested option must have the active CSS class — regression guard for the
+    // Lit-context isolation bug where cross-service notify() never reached
+    // nested options, leaving them without the highlighted state.
+    const applesOption = el.querySelector('auro-menuoption[value="apples"]');
+    await expect(applesOption.classList.contains('active')).toBe(true);
+  },
+};
+
+// ─── Nested menu: Enter selects, then reopen keeps keyboard flow stable ─────
+export const ComboboxNestedEnterSelectThenReopen: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-combobox noFilter>
+  <span slot="label">Nested Menu</span>
+  <auro-menu>
+    <auro-menuoption value="Stops">Stops</auro-menuoption>
+    <auro-menuoption value="Price">Price</auro-menuoption>
+    <auro-menu>
+      <auro-menuoption value="NestedApple">Nested Apple</auro-menuoption>
+      <auro-menuoption value="NestedOrange">Nested Orange</auro-menuoption>
+    </auro-menu>
+    <auro-menuoption value="Departure">Departure</auro-menuoption>
+  </auro-menu>
+</auro-combobox>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-combobox') as any;
+    await el.updateComplete;
+
+    setInputValue(el, 'st');
+    await new Promise((r) => setTimeout(r, 100));
+
+    const trigger = el.dropdown.querySelector('[slot="trigger"]') as HTMLElement;
+    trigger.click();
+    await new Promise((r) => setTimeout(r, 50));
+
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    await el.updateComplete;
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    await el.updateComplete;
+
+    await expect(el.value).toBe('Stops');
+    await expect(el.dropdown.isPopoverVisible).toBe(false);
+
+    setInputValue(el, 'de');
+    await new Promise((r) => setTimeout(r, 100));
+    trigger.click();
+    await new Promise((r) => setTimeout(r, 50));
+
+    await expect(el.dropdown.isPopoverVisible).toBe(true);
+    await expect(el.availableOptions.some((option: any) => option?.value === 'Departure')).toBe(true);
+  },
+};
+
+// ─── Nested menu: preserve original value case on selection ─────────────────
+export const ComboboxNestedSelectionPreservesCase: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-combobox noFilter>
+  <span slot="label">Nested Menu Case</span>
+  <auro-menu>
+    <auro-menuoption value="Alpha">Alpha</auro-menuoption>
+    <auro-menuoption value="Bravo">Bravo</auro-menuoption>
+    <auro-menu>
+      <auro-menuoption value="MixedCaseValue">Mixed Case Value</auro-menuoption>
+      <auro-menuoption value="AnotherNestedValue">Another Nested Value</auro-menuoption>
+    </auro-menu>
+  </auro-menu>
+</auro-combobox>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-combobox') as any;
+    await el.updateComplete;
+
+    setInputValue(el, 'mi');
+    await new Promise((r) => setTimeout(r, 100));
+
+    const trigger = el.dropdown.querySelector('[slot="trigger"]') as HTMLElement;
+    trigger.click();
+    await new Promise((r) => setTimeout(r, 50));
+
+    // ArrowDown: Alpha -> Bravo -> MixedCaseValue
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    await el.updateComplete;
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    await el.updateComplete;
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    await el.updateComplete;
+
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    await el.updateComplete;
+
+    await expect(el.value).toBe('MixedCaseValue');
+    await expect(el.optionSelected?.value).toBe('MixedCaseValue');
+  },
+};
+
+// ─── Nested menu: Enter selects nested option, then bib re-opens cleanly ──────
+export const ComboboxNestedEnterSelectNestedThenReopen: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-combobox noFilter>
+  <span slot="label">Nested Menu</span>
+  <auro-menu>
+    <auro-menuoption value="stops">Stops</auro-menuoption>
+    <auro-menuoption value="price">Price</auro-menuoption>
+    <auro-menu>
+      <auro-menuoption value="apples">Apples</auro-menuoption>
+      <auro-menuoption value="oranges">Oranges</auro-menuoption>
+    </auro-menu>
+    <auro-menuoption value="departure">Departure</auro-menuoption>
+  </auro-menu>
+</auro-combobox>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-combobox') as any;
+    await el.updateComplete;
+
+    setInputValue(el, 'ap');
+    await new Promise((r) => setTimeout(r, 100));
+
+    const trigger = el.dropdown.querySelector('[slot="trigger"]') as HTMLElement;
+    trigger.click();
+    await new Promise((r) => setTimeout(r, 50));
+
+    // 3x ArrowDown: null → stops → price → apples (nested)
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    await el.updateComplete;
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    await el.updateComplete;
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    await el.updateComplete;
+
+    await expect(el.optionActive.value).toBe('apples');
+
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    await new Promise((r) => setTimeout(r, 100));
+
+    await expect(el.value).toBe('apples');
+    await expect(el.dropdown.isPopoverVisible).toBe(false);
+
+    // Reopen with a different input — bib must open again cleanly
+    setInputValue(el, 'de');
+    await new Promise((r) => setTimeout(r, 100));
+    trigger.click();
+    await new Promise((r) => setTimeout(r, 50));
+
+    await expect(el.dropdown.isPopoverVisible).toBe(true);
+  },
+};
+
+// ─── Nested menu: nested selection then main leaves only main selected ────────
+export const ComboboxNestedSelectNestedThenMain: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-combobox noFilter>
+  <span slot="label">Nested Menu</span>
+  <auro-menu>
+    <auro-menuoption value="Stops">Stops</auro-menuoption>
+    <auro-menuoption value="Price">Price</auro-menuoption>
+    <auro-menu>
+      <auro-menuoption value="NestedApple">Nested Apple</auro-menuoption>
+      <auro-menuoption value="NestedOrange">Nested Orange</auro-menuoption>
+    </auro-menu>
+    <auro-menuoption value="Departure">Departure</auro-menuoption>
+  </auro-menu>
+</auro-combobox>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-combobox') as any;
+    await el.updateComplete;
+
+    // Select the nested option first
+    setInputValue(el, 'a');
+    await new Promise((r) => setTimeout(r, 100));
+    const trigger = el.dropdown.querySelector('[slot="trigger"]') as HTMLElement;
+    trigger.click();
+    await new Promise((r) => setTimeout(r, 50));
+
+    // 3x ArrowDown: null → Stops → Price → NestedApple
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    await el.updateComplete;
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    await el.updateComplete;
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    await el.updateComplete;
+
+    await expect(el.optionActive.value).toBe('NestedApple');
+
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    await new Promise((r) => setTimeout(r, 100));
+
+    await expect(el.value).toBe('NestedApple');
+    await expect(el.dropdown.isPopoverVisible).toBe(false);
+
+    // Reopen and select the main (top-level) option
+    setInputValue(el, 'st');
+    await new Promise((r) => setTimeout(r, 100));
+    trigger.click();
+    await new Promise((r) => setTimeout(r, 50));
+
+    // 1x ArrowDown: null → Stops
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    await el.updateComplete;
+
+    await expect(el.optionActive.value).toBe('Stops');
+
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    await new Promise((r) => setTimeout(r, 100));
+
+    await expect(el.value).toBe('Stops');
+    await expect(el.optionSelected?.value).toBe('Stops');
+
+    // Only Stops should be selected — guards against the dual-selection bug
+    const selectedOptions = [...canvasElement.querySelectorAll('auro-menuoption')].filter((opt: any) => opt.selected);
+    await expect(selectedOptions.length).toBe(1);
+    await expect((selectedOptions[0] as any).value).toBe('Stops');
+  },
+};
+
+// ─── Nested menu: main selection then nested leaves only nested selected ──────
+export const ComboboxNestedSingleSelectExclusivityMainToNested: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-combobox noFilter>
+  <span slot="label">Nested Menu</span>
+  <auro-menu>
+    <auro-menuoption value="Stops">Stops</auro-menuoption>
+    <auro-menuoption value="Price">Price</auro-menuoption>
+    <auro-menu>
+      <auro-menuoption value="NestedApple">Nested Apple</auro-menuoption>
+      <auro-menuoption value="NestedOrange">Nested Orange</auro-menuoption>
+    </auro-menu>
+    <auro-menuoption value="Departure">Departure</auro-menuoption>
+  </auro-menu>
+</auro-combobox>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-combobox') as any;
+    await el.updateComplete;
+
+    // Select the main option first
+    setInputValue(el, 'a');
+    await new Promise((r) => setTimeout(r, 100));
+    const trigger = el.dropdown.querySelector('[slot="trigger"]') as HTMLElement;
+    trigger.click();
+    await new Promise((r) => setTimeout(r, 50));
+
+    // 1x ArrowDown: null → Stops
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    await el.updateComplete;
+
+    await expect(el.optionActive.value).toBe('Stops');
+
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    await new Promise((r) => setTimeout(r, 100));
+
+    await expect(el.value).toBe('Stops');
+    await expect(el.dropdown.isPopoverVisible).toBe(false);
+
+    // Reopen and select the nested option
+    setInputValue(el, 'a');
+    await new Promise((r) => setTimeout(r, 100));
+    trigger.click();
+    await new Promise((r) => setTimeout(r, 50));
+
+    // 3x ArrowDown: null → Stops → Price → NestedApple
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    await el.updateComplete;
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    await el.updateComplete;
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    await el.updateComplete;
+
+    await expect(el.optionActive.value).toBe('NestedApple');
+
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    await new Promise((r) => setTimeout(r, 100));
+
+    await expect(el.value).toBe('NestedApple');
+    await expect(el.optionSelected?.value).toBe('NestedApple');
+
+    // Only NestedApple should be selected — guards against the dual-selection bug
+    const selectedOptions = [...canvasElement.querySelectorAll('auro-menuoption')].filter((opt: any) => opt.selected);
+    await expect(selectedOptions.length).toBe(1);
+    await expect((selectedOptions[0] as any).value).toBe('NestedApple');
   },
 };

--- a/components/combobox/test/auro-combobox.test.js
+++ b/components/combobox/test/auro-combobox.test.js
@@ -1571,6 +1571,347 @@ function buildFocusedClearBtnCtx() {
   };
 }
 
+// ─── Nested menu keyboard navigation ─────────────────────────────────────────
+// Uses nofilter so all nested options remain visible regardless of input text.
+// Tests dispatch directly on `el` with elementUpdated — no oneEvent/waitUntil
+// so these fail fast with wrong-value assertions rather than hanging.
+
+async function nestedComboboxMenuFixture(mobileview = false) {
+  if (mobileview) {
+    await setViewport({ width: 500, height: 800 });
+  } else {
+    await setViewport({ width: 800, height: 800 });
+  }
+  return await fixture(html`
+    <auro-combobox nofilter>
+      <span slot="label">Nested Menu</span>
+      <auro-menu>
+        <auro-menuoption value="stops">Stops</auro-menuoption>
+        <auro-menuoption value="price">Price</auro-menuoption>
+        <auro-menu>
+          <auro-menuoption value="apples">Apples</auro-menuoption>
+          <auro-menuoption value="oranges">Oranges</auro-menuoption>
+        </auro-menu>
+        <auro-menuoption value="departure">Departure</auro-menuoption>
+      </auro-menu>
+    </auro-combobox>
+  `);
+}
+
+[false, true].forEach((mobileview) => {
+  const label = mobileview ? '(fullscreen)' : '(desktop)';
+
+  describe(`nested menu keyboard navigation ${label}`, () => {
+    it(`ArrowDown enters the nested submenu after the last pre-nested option ${label}`, async () => {
+      const el = await nestedComboboxMenuFixture(mobileview);
+
+      el.focus();
+      setInputValue(el, 'a');
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      await elementUpdated(el);
+
+      if (mobileview) {
+        await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+      }
+
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      await elementUpdated(el);
+      expect(el.optionActive.value).to.equal('stops');
+
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      await elementUpdated(el);
+      expect(el.optionActive.value).to.equal('price');
+
+      // Fails until fix is in — currently wraps back to stops instead of entering nested menu
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      await elementUpdated(el);
+      expect(el.optionActive.value).to.equal('apples');
+    });
+
+    it(`ArrowDown traverses all options across nesting levels in DOM order ${label}`, async () => {
+      const el = await nestedComboboxMenuFixture(mobileview);
+
+      el.focus();
+      setInputValue(el, 'a');
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      await elementUpdated(el);
+
+      if (mobileview) {
+        await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+      }
+
+      const expectedOrder = ['stops', 'price', 'apples', 'oranges', 'departure'];
+      for (const value of expectedOrder) {
+        el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+        await elementUpdated(el);
+        expect(el.optionActive.value).to.equal(value);
+      }
+    });
+
+    it(`ArrowUp navigates backwards from a nested option into the pre-nested options ${label}`, async () => {
+      const el = await nestedComboboxMenuFixture(mobileview);
+
+      el.focus();
+      setInputValue(el, 'a');
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      await elementUpdated(el);
+
+      if (mobileview) {
+        await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+      }
+
+      // Navigate forward to apples (3 presses)
+      for (let i = 0; i < 3; i++) {
+        el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+        await elementUpdated(el);
+      }
+      expect(el.optionActive.value).to.equal('apples');
+
+      // ArrowUp from apples should go back to price
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' }));
+      await elementUpdated(el);
+      expect(el.optionActive.value).to.equal('price');
+    });
+  });
+});
+
+async function nestedCaseComboboxFixture(mobileview = false) {
+  if (mobileview) {
+    await setViewport({ width: 500, height: 800 });
+  } else {
+    await setViewport({ width: 800, height: 800 });
+  }
+  return await fixture(html`
+    <auro-combobox nofilter>
+      <span slot="label">Nested Menu Case</span>
+      <auro-menu>
+        <auro-menuoption value="Alpha">Alpha</auro-menuoption>
+        <auro-menuoption value="Bravo">Bravo</auro-menuoption>
+        <auro-menu>
+          <auro-menuoption value="MixedCaseValue">Mixed Case Value</auro-menuoption>
+          <auro-menuoption value="AnotherNestedValue">Another Nested Value</auro-menuoption>
+        </auro-menu>
+      </auro-menu>
+    </auro-combobox>
+  `);
+}
+
+[false, true].forEach((mobileview) => {
+  const label = mobileview ? '(fullscreen)' : '(desktop)';
+
+  describe(`nested menu selection behavior ${label}`, () => {
+    it(`selects with Enter, then supports reopening and selecting again ${label}`, async () => {
+      const el = await nestedComboboxMenuFixture(mobileview);
+
+      el.focus();
+      setInputValue(el, 'st');
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      await elementUpdated(el);
+
+      if (mobileview) {
+        await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+      }
+
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      await elementUpdated(el);
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      await elementUpdated(el);
+      // makeSelection fires an event that triggers hideBib() asynchronously;
+      // wait a frame for the popover to close before asserting visibility.
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(el.value).to.equal('stops');
+      expect(el.dropdown.isPopoverVisible).to.be.false;
+
+      setInputValue(el, 'de');
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      await elementUpdated(el);
+
+      if (mobileview) {
+        await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+      }
+
+      expect(el.dropdown.isPopoverVisible).to.be.true;
+      expect(el.availableOptions.some((option) => option?.value === 'departure')).to.be.true;
+    });
+
+    it(`preserves original case for nested option values when selected ${label}`, async () => {
+      const el = await nestedCaseComboboxFixture(mobileview);
+
+      el.focus();
+      setInputValue(el, 'mi');
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      await elementUpdated(el);
+
+      if (mobileview) {
+        await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+      }
+
+      // ArrowDown: Alpha -> Bravo -> MixedCaseValue
+      for (let i = 0; i < 3; i++) {
+        el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+        await elementUpdated(el);
+      }
+
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      await elementUpdated(el);
+
+      expect(el.value).to.equal('MixedCaseValue');
+      expect(el.optionSelected?.value).to.equal('MixedCaseValue');
+    });
+
+    it(`selects nested option with Enter, then bib re-opens cleanly ${label}`, async () => {
+      const el = await nestedComboboxMenuFixture(mobileview);
+
+      el.focus();
+      setInputValue(el, 'ap');
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      await elementUpdated(el);
+
+      if (mobileview) {
+        await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+      }
+
+      // 3x ArrowDown: null → stops → price → apples (nested)
+      for (let i = 0; i < 3; i++) {
+        el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+        await elementUpdated(el);
+      }
+      expect(el.optionActive.value).to.equal('apples');
+
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      await elementUpdated(el);
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(el.value).to.equal('apples');
+      expect(el.dropdown.isPopoverVisible).to.be.false;
+
+      setInputValue(el, 'de');
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      await elementUpdated(el);
+
+      if (mobileview) {
+        await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+      }
+
+      expect(el.dropdown.isPopoverVisible).to.be.true;
+    });
+
+    it(`selecting nested option then main option leaves only main selected ${label}`, async () => {
+      const el = await nestedComboboxMenuFixture(mobileview);
+
+      el.focus();
+      setInputValue(el, 'a');
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      await elementUpdated(el);
+
+      if (mobileview) {
+        await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+      }
+
+      // 3x ArrowDown: null → stops → price → apples (nested)
+      for (let i = 0; i < 3; i++) {
+        el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+        await elementUpdated(el);
+      }
+      expect(el.optionActive.value).to.equal('apples');
+
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      await elementUpdated(el);
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(el.value).to.equal('apples');
+      expect(el.dropdown.isPopoverVisible).to.be.false;
+
+      setInputValue(el, 'st');
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      await elementUpdated(el);
+
+      if (mobileview) {
+        await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+      }
+
+      // After reopen, optionActive should be null; 1x ArrowDown reaches stops.
+      // This WILL FAIL until the bug is fixed that leaves active pointing at the
+      // previously-selected nested option instead of resetting cleanly.
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      await elementUpdated(el);
+
+      expect(el.optionActive.value).to.equal('stops');
+
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      await elementUpdated(el);
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(el.value).to.equal('stops');
+      expect(el.optionSelected?.value).to.equal('stops');
+
+      // Only stops should be selected — guards against the dual-selection bug
+      const selectedOptions = [...el.querySelectorAll('auro-menuoption')].filter(
+        (option) => option.selected
+      );
+      expect(selectedOptions.length).to.equal(1);
+      expect(selectedOptions[0].value).to.equal('stops');
+    });
+
+    it(`selecting main option then nested option leaves only nested selected ${label}`, async () => {
+      const el = await nestedComboboxMenuFixture(mobileview);
+
+      el.focus();
+      setInputValue(el, 'a');
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      await elementUpdated(el);
+
+      if (mobileview) {
+        await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+      }
+
+      // 1x ArrowDown: null → stops
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      await elementUpdated(el);
+      expect(el.optionActive.value).to.equal('stops');
+
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      await elementUpdated(el);
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(el.value).to.equal('stops');
+      expect(el.dropdown.isPopoverVisible).to.be.false;
+
+      setInputValue(el, 'a');
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      await elementUpdated(el);
+
+      if (mobileview) {
+        await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+      }
+
+      // After reopen, optionActive should be null; 3x ArrowDown reaches apples.
+      // This WILL FAIL until the bug is fixed that offsets navigation by
+      // leaving active on the previously-selected option instead of null.
+      for (let i = 0; i < 3; i++) {
+        el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+        await elementUpdated(el);
+      }
+      expect(el.optionActive.value).to.equal('apples');
+
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      await elementUpdated(el);
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(el.value).to.equal('apples');
+      expect(el.optionSelected?.value).to.equal('apples');
+
+      // Only apples should be selected — guards against the dual-selection bug
+      const selectedOptions = [...el.querySelectorAll('auro-menuoption')].filter(
+        (option) => option.selected
+      );
+      expect(selectedOptions.length).to.equal(1);
+      expect(selectedOptions[0].value).to.equal('apples');
+    });
+  });
+});
+
 describe('comboboxKeyboardStrategy — arrow keys when clear button has focus', () => {
   ['ArrowDown', 'ArrowUp'].forEach((key) => {
     it(`${key}: returns early without calling showBib or navigateOptions`, () => {

--- a/components/menu/src/auro-menu.context.js
+++ b/components/menu/src/auro-menu.context.js
@@ -21,7 +21,7 @@ export class MenuService {
    * @returns {AuroMenuOption|null}
    */
   get highlightedOption() {
-    return this._menuOptions[this.highlightedIndex] || null;
+    return this._highlightedOption;
   }
 
   /**
@@ -109,6 +109,7 @@ export class MenuService {
     this.selectAllMatchingOptions = undefined;
 
     this.highlightedIndex = -1;
+    this._highlightedOption = null;
 
     this._menuOptions = [];
     this._subscribers = [];
@@ -159,6 +160,7 @@ export class MenuService {
     this._pendingValue = null;
     this._pendingRetryScheduled = false;
     this._pendingRetryCount = 0;
+    this._highlightedOption = null;
   }
 
   /**
@@ -216,8 +218,12 @@ export class MenuService {
    */
   moveHighlightedOption(direction) {
 
-    // Get the active options
-    const activeOptions = this._menuOptions.filter(option => option.isActive);
+    // Build a flattened list of all active options from the full menu subtree in
+    // DOM order so that nested <auro-menu> options participate in traversal.
+    // querySelectorAll walks the entire light-DOM subtree and is not limited to
+    // direct children, which is what caused nested options to be unreachable.
+    const allOptions = Array.from(this.host.querySelectorAll('auro-menuoption, [auro-menuoption]'));
+    const activeOptions = allOptions.filter(option => option.isActive);
 
     // Get the currently active option
     const currentActiveOption = activeOptions[activeOptions.indexOf(this.highlightedOption)];
@@ -247,14 +253,38 @@ export class MenuService {
 
     if (!option) return;
 
-    // Get the index of the option to highlight
+    // If the previously highlighted option belongs to a nested menu's own
+    // MenuService (i.e. not in this._menuOptions), notify() won't reach it —
+    // subscribers are per-service. Deactivate it directly so it loses its
+    // highlighted CSS class before we move on.
+    const prevOption = this._highlightedOption;
+    if (prevOption && !this._menuOptions.includes(prevOption)) {
+      prevOption.active = false;
+      prevOption.updateActiveClasses();
+    }
+
+    // Track by direct reference so nested options (not in _menuOptions) are
+    // correctly remembered for the next navigation call.
+    this._highlightedOption = option;
+
+    // highlightedIndex reflects position within the registered _menuOptions array.
+    // For options that live in a nested menu's own MenuService this will be -1,
+    // which is acceptable — the index is informational only.
     const index = this._menuOptions.indexOf(option);
 
     // Update highlighted index
     this.highlightedIndex = index;
 
-    // Notify subscribers of highlight change
+    // Notify root-level subscribers of the highlight change. This correctly
+    // activates/deactivates options that subscribed to THIS service.
     this.notify({ type: 'highlightChange', option, index: this.highlightedIndex });
+
+    // If the new option is nested (not in this._menuOptions), notify() won't
+    // reach it either. Activate it directly so it gains the highlighted class.
+    if (!this._menuOptions.includes(option)) {
+      option.active = true;
+      option.updateActiveClasses();
+    }
 
     // Dispatch the change event
     this.dispatchChangeEvent('auroMenu-activatedOption', option);
@@ -267,6 +297,20 @@ export class MenuService {
   setHighlightedIndex(index) {
     const option = this._menuOptions[index] || null;
     this.setHighlightedOption(option);
+  }
+
+  /**
+   * Clears the highlighted option and removes its active CSS class.
+   * Call this when the dropdown closes so the next open starts from a clean state.
+   */
+  clearHighlight() {
+    const prev = this._highlightedOption;
+    if (prev) {
+      prev.active = false;
+      prev.updateActiveClasses();
+    }
+    this._highlightedOption = null;
+    this.highlightedIndex = -1;
   }
 
   /**
@@ -417,6 +461,26 @@ export class MenuService {
         return;
       }
 
+      // Before treating this as a hard miss, scan the full DOM subtree for
+      // nested menuoptions whose keys match. Nested options register with
+      // their own MenuService instance (context isolation), so they never
+      // appear in this._menuOptions.
+      const allOptions = Array.from(this.host.querySelectorAll('auro-menuoption, [auro-menuoption]'));
+      const nestedMatches = allOptions.filter(option =>
+        !this._menuOptions.includes(option) &&
+        option.isActive &&
+        validatedValues.includes(option.key)
+      );
+
+      if (nestedMatches.length) {
+        this.clearPendingValue();
+        const selected = this.multiSelect ? nestedMatches : [nestedMatches[nestedMatches.length - 1]];
+        if (this.optionsArraysMatch(selected, this.selectedOptions)) return;
+        this.selectedOptions = selected;
+        this.stageUpdate();
+        return;
+      }
+
       this.clearPendingValue();
 
       if (this.selectedOptions.length > 0) {
@@ -542,6 +606,16 @@ export class MenuService {
       type: 'stateChange',
       selectedOptions: this.selectedOptions,
       ...meta
+    });
+
+    // Options subscribed to a nested menu's own service never receive the
+    // notify() broadcast above. Sync their selected state directly so the
+    // DOM attribute stays accurate and dual-selection cannot occur.
+    const allOptions = Array.from(this.host.querySelectorAll('auro-menuoption, [auro-menuoption]'));
+    allOptions.forEach(option => {
+      if (!this._menuOptions.includes(option)) {
+        option.setInternalSelected(this.selectedOptions.includes(option));
+      }
     });
   }
 

--- a/components/menu/stories/component.stories.ts
+++ b/components/menu/stories/component.stories.ts
@@ -21,67 +21,6 @@ export default meta;
 
 type Story = StoryObj;
 
-// ─── ArrowDown activates first option ────────────────────────────────────────
-export const MenuArrowDownActivatesOption: Story = {
-  tags: ['!autodocs', 'chromatic-enabled'],
-  render: () => html`
-<auro-menu>
-  <auro-menuoption value="apples">Apples</auro-menuoption>
-  <auro-menuoption value="oranges">Oranges</auro-menuoption>
-  <auro-menuoption value="grapes">Grapes</auro-menuoption>
-</auro-menu>
-  `,
-  async play({ canvasElement }: { canvasElement: HTMLElement }) {
-    const el = canvasElement.querySelector('auro-menu') as any;
-    const options = [...canvasElement.querySelectorAll('auro-menuoption')] as HTMLElement[];
-    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, composed: true }));
-    await el.updateComplete;
-    await expect(el.optionActive).toBe(options[0]);
-    await expect(options[0].classList.contains('active')).toBe(true);
-  },
-};
-
-// ─── ArrowDown wraps from last back to first ──────────────────────────────────
-export const MenuArrowDownWraps: Story = {
-  tags: ['!autodocs', 'chromatic-enabled'],
-  render: () => html`
-<auro-menu>
-  <auro-menuoption value="apples">Apples</auro-menuoption>
-  <auro-menuoption value="oranges">Oranges</auro-menuoption>
-  <auro-menuoption value="grapes">Grapes</auro-menuoption>
-</auro-menu>
-  `,
-  async play({ canvasElement }: { canvasElement: HTMLElement }) {
-    const el = canvasElement.querySelector('auro-menu') as any;
-    const options = [...canvasElement.querySelectorAll('auro-menuoption')] as HTMLElement[];
-    // options.length + 1 downs wraps back to first option
-    for (let i = 0; i < options.length + 1; i++) {
-      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, composed: true }));
-      await el.updateComplete;
-    }
-    await expect(el.optionActive).toBe(options[0]);
-  },
-};
-
-// ─── ArrowUp wraps from top to last option ────────────────────────────────────
-export const MenuArrowUpWraps: Story = {
-  tags: ['!autodocs', 'chromatic-enabled'],
-  render: () => html`
-<auro-menu>
-  <auro-menuoption value="apples">Apples</auro-menuoption>
-  <auro-menuoption value="oranges">Oranges</auro-menuoption>
-  <auro-menuoption value="grapes">Grapes</auro-menuoption>
-</auro-menu>
-  `,
-  async play({ canvasElement }: { canvasElement: HTMLElement }) {
-    const el = canvasElement.querySelector('auro-menu') as any;
-    const options = [...canvasElement.querySelectorAll('auro-menuoption')] as HTMLElement[];
-    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true, composed: true }));
-    await el.updateComplete;
-    await expect(el.optionActive).toBe(options[options.length - 1]);
-  },
-};
-
 // ─── Enter selects the highlighted option ────────────────────────────────────
 export const MenuEnterSelectsOption: Story = {
   tags: ['!autodocs', 'chromatic-enabled'],
@@ -101,27 +40,6 @@ export const MenuEnterSelectsOption: Story = {
     await el.updateComplete;
     await expect(options[0].hasAttribute('selected')).toBe(true);
     await expect(el.optionSelected).toBe(options[0]);
-  },
-};
-
-// ─── ArrowDown skips disabled and hidden options ──────────────────────────────
-export const MenuArrowDownSkipsDisabled: Story = {
-  tags: ['!autodocs', 'chromatic-enabled'],
-  render: () => html`
-<auro-menu>
-  <auro-menuoption disabled value="apples">Apples</auro-menuoption>
-  <auro-menuoption hidden value="oranges">Oranges</auro-menuoption>
-  <auro-menuoption value="grapes">Grapes</auro-menuoption>
-  <auro-menuoption value="mango">Mango</auro-menuoption>
-</auro-menu>
-  `,
-  async play({ canvasElement }: { canvasElement: HTMLElement }) {
-    const el = canvasElement.querySelector('auro-menu') as any;
-    const options = [...canvasElement.querySelectorAll('auro-menuoption')] as HTMLElement[];
-    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, composed: true }));
-    await el.updateComplete;
-    // disabled options[0] and hidden options[1] should be skipped; land on options[2]
-    await expect(el.optionActive).toBe(options[2]);
   },
 };
 

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -557,6 +557,7 @@ export class AuroSelect extends AuroElement {
       if (!this.dropdown.isPopoverVisible) {
         this.dropdown.setActiveDescendant(null);
         this.optionActive = null;
+        this.menu.menuService.clearHighlight();
 
         restoreTriggerAfterClose(this.dropdown, this.dropdown.trigger);
       }

--- a/components/select/stories/component.stories.ts
+++ b/components/select/stories/component.stories.ts
@@ -397,3 +397,355 @@ export const SelectFullscreenEnterOnCloseSelectsActiveOption: Story = {
   },
 };
 
+// ─── Nested menu: ArrowDown reaches options inside a nested auro-menu ────────
+export const SelectNestedMenuKeyboardNav: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-select>
+  <span slot="label">Sort by</span>
+  <auro-menu>
+    <auro-menuoption value="stops">Stops</auro-menuoption>
+    <auro-menuoption value="price">Price</auro-menuoption>
+    <auro-menu>
+      <auro-menuoption value="apples">Apples</auro-menuoption>
+      <auro-menuoption value="oranges">Oranges</auro-menuoption>
+    </auro-menu>
+    <auro-menuoption value="departure">Departure</auro-menuoption>
+  </auro-menu>
+</auro-select>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-select') as any;
+    const trigger = el.dropdown.shadowRoot.querySelector('#trigger');
+
+    await userEvent.click(trigger);
+    await expect(el.isPopoverVisible).toBe(true);
+
+    // ArrowDown three times: stops → price → apples (nested)
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Nested option must be reached — regression guard for the Lit-context
+    // isolation bug where options inside a child auro-menu were unreachable.
+    const applesOption = el.querySelector('auro-menuoption[value="apples"]');
+    await expect(applesOption.classList.contains('active')).toBe(true);
+  },
+};
+
+// ─── Nested menu: select nested then main in single-select mode ─────────────
+export const SelectNestedThenMainSingleSelect: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-select>
+  <span slot="label">Sort by</span>
+  <auro-menu>
+    <auro-menuoption value="stops">Stops</auro-menuoption>
+    <auro-menuoption value="price">Price</auro-menuoption>
+    <auro-menu>
+      <auro-menuoption value="apples">Apples</auro-menuoption>
+      <auro-menuoption value="oranges">Oranges</auro-menuoption>
+    </auro-menu>
+    <auro-menuoption value="departure">Departure</auro-menuoption>
+  </auro-menu>
+</auro-select>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-select') as any;
+    const trigger = el.dropdown.shadowRoot.querySelector('#trigger');
+
+    await userEvent.click(trigger);
+    await expect(el.isPopoverVisible).toBe(true);
+
+    const nestedOption = el.querySelector('auro-menuoption[value="apples"]');
+    await userEvent.click(nestedOption);
+    await wait(50);
+
+    await expect(el.value).toBe('apples');
+    await expect(el.isPopoverVisible).toBe(false);
+
+    await userEvent.click(trigger);
+    await expect(el.isPopoverVisible).toBe(true);
+
+    const mainOption = el.querySelector('auro-menuoption[value="stops"]');
+    await userEvent.click(mainOption);
+    await wait(50);
+
+    const selectedOptions = [...el.querySelectorAll('auro-menuoption')].filter((option: any) => option.selected);
+    await expect(el.value).toBe('stops');
+    await expect(el.optionSelected?.value).toBe('stops');
+    await expect(selectedOptions.length).toBe(1);
+  },
+};
+
+// ─── Nested menu: Enter selection then reopen remains selectable ─────────────
+export const SelectNestedEnterThenReopen: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-select>
+  <span slot="label">Sort by</span>
+  <auro-menu>
+    <auro-menuoption value="stops">Stops</auro-menuoption>
+    <auro-menuoption value="price">Price</auro-menuoption>
+    <auro-menu>
+      <auro-menuoption value="apples">Apples</auro-menuoption>
+      <auro-menuoption value="oranges">Oranges</auro-menuoption>
+    </auro-menu>
+  </auro-menu>
+</auro-select>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-select') as any;
+    const trigger = el.dropdown.shadowRoot.querySelector('#trigger');
+
+    await userEvent.click(trigger);
+    await expect(el.isPopoverVisible).toBe(true);
+
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    await wait(50);
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    await wait(50);
+
+    await expect(el.value).toBe('apples');
+    await expect(el.isPopoverVisible).toBe(false);
+
+    await userEvent.click(trigger);
+    await expect(el.isPopoverVisible).toBe(true);
+
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    await wait(50);
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    await wait(50);
+
+    await expect(el.value).toBe('stops');
+    await expect(el.optionSelected?.value).toBe('stops');
+  },
+};
+
+// ─── Nested menu with multiselect: nested and main options can coexist ──────
+export const SelectNestedMultiselectMixedSelection: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-select multiselect>
+  <span slot="label">Sort by</span>
+  <auro-menu>
+    <auro-menuoption value="stops">Stops</auro-menuoption>
+    <auro-menuoption value="price">Price</auro-menuoption>
+    <auro-menu>
+      <auro-menuoption value="apples">Apples</auro-menuoption>
+      <auro-menuoption value="oranges">Oranges</auro-menuoption>
+    </auro-menu>
+  </auro-menu>
+</auro-select>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-select') as any;
+    const trigger = el.dropdown.shadowRoot.querySelector('#trigger');
+
+    await userEvent.click(trigger);
+    await expect(el.isPopoverVisible).toBe(true);
+
+    const nestedOption = el.querySelector('auro-menuoption[value="apples"]');
+    await userEvent.click(nestedOption);
+    await wait(50);
+
+    const mainOption = el.querySelector('auro-menuoption[value="stops"]');
+    await userEvent.click(mainOption);
+    await wait(50);
+
+    const parsed = JSON.parse(el.value);
+    await expect(parsed).toContain('apples');
+    await expect(parsed).toContain('stops');
+    await expect(Array.isArray(el.optionSelected)).toBe(true);
+    await expect(el.optionSelected.length).toBe(2);
+  },
+};
+
+// ─── Nested menu: main selection then nested leaves only nested selected ──────
+export const SelectNestedMainThenNestedSingleSelect: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-select>
+  <span slot="label">Sort by</span>
+  <auro-menu>
+    <auro-menuoption value="stops">Stops</auro-menuoption>
+    <auro-menuoption value="price">Price</auro-menuoption>
+    <auro-menu>
+      <auro-menuoption value="apples">Apples</auro-menuoption>
+      <auro-menuoption value="oranges">Oranges</auro-menuoption>
+    </auro-menu>
+    <auro-menuoption value="departure">Departure</auro-menuoption>
+  </auro-menu>
+</auro-select>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-select') as any;
+    const trigger = el.dropdown.shadowRoot.querySelector('#trigger');
+
+    await userEvent.click(trigger);
+    await expect(el.isPopoverVisible).toBe(true);
+
+    const stopsOption = el.querySelector('auro-menuoption[value="stops"]');
+    await userEvent.click(stopsOption);
+    await wait(50);
+
+    await expect(el.value).toBe('stops');
+    await expect(el.isPopoverVisible).toBe(false);
+
+    await userEvent.click(trigger);
+    await expect(el.isPopoverVisible).toBe(true);
+
+    const applesOption = el.querySelector('auro-menuoption[value="apples"]');
+    await userEvent.click(applesOption);
+    await wait(50);
+
+    await expect(el.value).toBe('apples');
+    await expect(el.optionSelected?.value).toBe('apples');
+    // Only apples should be selected — guards against the dual-selection bug
+    const selectedOptions = [...el.querySelectorAll('auro-menuoption')].filter((opt: any) => opt.selected);
+    await expect(selectedOptions.length).toBe(1);
+  },
+};
+
+// ─── Nested menu: keyboard-only main then nested leaves only nested selected ──
+export const SelectNestedKeyboardExclusivityBothDirections: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-select>
+  <span slot="label">Sort by</span>
+  <auro-menu>
+    <auro-menuoption value="stops">Stops</auro-menuoption>
+    <auro-menuoption value="price">Price</auro-menuoption>
+    <auro-menu>
+      <auro-menuoption value="apples">Apples</auro-menuoption>
+      <auro-menuoption value="oranges">Oranges</auro-menuoption>
+    </auro-menu>
+    <auro-menuoption value="departure">Departure</auro-menuoption>
+  </auro-menu>
+</auro-select>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-select') as any;
+    const trigger = el.dropdown.shadowRoot.querySelector('#trigger');
+
+    await userEvent.click(trigger);
+    await expect(el.isPopoverVisible).toBe(true);
+
+    // 1x ArrowDown → stops; Enter selects and closes bib
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    await wait(50);
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    await wait(50);
+
+    await expect(el.value).toBe('stops');
+    await expect(el.isPopoverVisible).toBe(false);
+
+    // Reopen and navigate 3x to apples (nested); Enter selects apples
+    await userEvent.click(trigger);
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    await wait(50);
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    await wait(50);
+
+    await expect(el.value).toBe('apples');
+    await expect(el.optionSelected?.value).toBe('apples');
+    // Only apples should be selected — guards against the dual-selection bug
+    const selectedOptions = [...el.querySelectorAll('auro-menuoption')].filter((opt: any) => opt.selected);
+    await expect(selectedOptions.length).toBe(1);
+    const stopsOption = el.querySelector('auro-menuoption[value="stops"]') as any;
+    await expect(stopsOption.selected).toBe(false);
+  },
+};
+
+// ─── Nested menu with multiselect: deselecting a nested option removes it ────
+export const SelectNestedMultiselectDeselect: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-select multiselect>
+  <span slot="label">Sort by</span>
+  <auro-menu>
+    <auro-menuoption value="stops">Stops</auro-menuoption>
+    <auro-menuoption value="price">Price</auro-menuoption>
+    <auro-menu>
+      <auro-menuoption value="apples">Apples</auro-menuoption>
+      <auro-menuoption value="oranges">Oranges</auro-menuoption>
+    </auro-menu>
+  </auro-menu>
+</auro-select>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-select') as any;
+    const trigger = el.dropdown.shadowRoot.querySelector('#trigger');
+
+    await userEvent.click(trigger);
+    await expect(el.isPopoverVisible).toBe(true);
+
+    const applesOption = el.querySelector('auro-menuoption[value="apples"]') as any;
+    await userEvent.click(applesOption);
+    await wait(50);
+
+    await expect(applesOption.selected).toBe(true);
+
+    // Reopen and click apples again to deselect it
+    await userEvent.click(trigger);
+    await expect(el.isPopoverVisible).toBe(true);
+
+    await userEvent.click(applesOption);
+    await wait(50);
+
+    await expect(applesOption.selected).toBe(false);
+    await expect(el.value).toBeFalsy();
+  },
+};
+
+// ─── Nested menu with multiselect: keyboard selects nested and main ───────────
+export const SelectNestedMultiselectKeyboard: Story = {
+  tags: ['!autodocs', 'chromatic-enabled'],
+  render: () => html`
+<auro-select multiselect>
+  <span slot="label">Sort by</span>
+  <auro-menu>
+    <auro-menuoption value="stops">Stops</auro-menuoption>
+    <auro-menuoption value="price">Price</auro-menuoption>
+    <auro-menu>
+      <auro-menuoption value="apples">Apples</auro-menuoption>
+      <auro-menuoption value="oranges">Oranges</auro-menuoption>
+    </auro-menu>
+  </auro-menu>
+</auro-select>
+  `,
+  async play({ canvasElement }: { canvasElement: HTMLElement }) {
+    const el = canvasElement.querySelector('auro-select') as any;
+    const trigger = el.dropdown.shadowRoot.querySelector('#trigger');
+
+    await userEvent.click(trigger);
+    await expect(el.isPopoverVisible).toBe(true);
+
+    // 3x ArrowDown → apples (nested); Enter selects
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    await wait(50);
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    await wait(50);
+
+    // Reopen and keyboard-select stops (main)
+    await userEvent.click(trigger);
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    await wait(50);
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    await wait(50);
+
+    const parsed = JSON.parse(el.value);
+    await expect(parsed).toContain('apples');
+    await expect(parsed).toContain('stops');
+    await expect(Array.isArray(el.optionSelected)).toBe(true);
+    await expect(el.optionSelected.length).toBe(2);
+  },
+};
+

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -1167,3 +1167,494 @@ describe('selectKeyboardStrategy — Tab multiselect', () => {
     expect(hideCalled).to.be.true;
   });
 });
+
+// ─── Nested menu keyboard navigation ─────────────────────────────────────────
+// Tests dispatch directly on `el` and check el.menu.optionActive after each
+// elementUpdated — no oneEvent/waitUntil so these fail fast with wrong-value
+// assertions rather than hanging on a timeout.
+
+async function nestedSelectMenuFixture() {
+  return await fixture(html`
+    <auro-select>
+      <span slot="label">Nested Menu</span>
+      <auro-menu>
+        <auro-menuoption value="stops">Stops</auro-menuoption>
+        <auro-menuoption value="price">Price</auro-menuoption>
+        <auro-menu>
+          <auro-menuoption value="apples">Apples</auro-menuoption>
+          <auro-menuoption value="oranges">Oranges</auro-menuoption>
+        </auro-menu>
+        <auro-menuoption value="departure">Departure</auro-menuoption>
+      </auro-menu>
+    </auro-select>
+  `);
+}
+
+describe('nested menu keyboard navigation', () => {
+  it('ArrowDown enters the nested submenu after the last pre-nested option', async () => {
+    await setScreenSize(false);
+    const el = await nestedSelectMenuFixture();
+    const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+    const trigger = dropdown.querySelector('[slot="trigger"]');
+
+    trigger.click();
+    await elementUpdated(el);
+
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    await elementUpdated(el);
+    expect(el.menu.optionActive.value).to.equal('stops');
+
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    await elementUpdated(el);
+    expect(el.menu.optionActive.value).to.equal('price');
+
+    // Fails until fix is in — currently wraps back to stops instead of entering nested menu
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    await elementUpdated(el);
+    expect(el.menu.optionActive.value).to.equal('apples');
+  });
+
+  it('ArrowDown traverses all options across nesting levels in DOM order', async () => {
+    await setScreenSize(false);
+    const el = await nestedSelectMenuFixture();
+    const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+    const trigger = dropdown.querySelector('[slot="trigger"]');
+
+    trigger.click();
+    await elementUpdated(el);
+
+    const expectedOrder = ['stops', 'price', 'apples', 'oranges', 'departure'];
+    for (const value of expectedOrder) {
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      await elementUpdated(el);
+      expect(el.menu.optionActive.value).to.equal(value);
+    }
+  });
+
+  it('ArrowDown wraps from the last post-nested option to the first option', async () => {
+    await setScreenSize(false);
+    const el = await nestedSelectMenuFixture();
+    const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+    const trigger = dropdown.querySelector('[slot="trigger"]');
+
+    trigger.click();
+    await elementUpdated(el);
+
+    // Navigate past all 5 options
+    for (let i = 0; i < 5; i++) {
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      await elementUpdated(el);
+    }
+
+    // 6th press should wrap to stops
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    await elementUpdated(el);
+    expect(el.menu.optionActive.value).to.equal('stops');
+  });
+
+  it('ArrowUp navigates backwards from a nested option into the pre-nested options', async () => {
+    await setScreenSize(false);
+    const el = await nestedSelectMenuFixture();
+    const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+    const trigger = dropdown.querySelector('[slot="trigger"]');
+
+    trigger.click();
+    await elementUpdated(el);
+
+    // Navigate forward to apples (3 presses)
+    for (let i = 0; i < 3; i++) {
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      await elementUpdated(el);
+    }
+    expect(el.menu.optionActive.value).to.equal('apples');
+
+    // ArrowUp from apples should go back to price
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' }));
+    await elementUpdated(el);
+    expect(el.menu.optionActive.value).to.equal('price');
+  });
+
+  it('ArrowUp wraps from the first option to the last post-nested option', async () => {
+    await setScreenSize(false);
+    const el = await nestedSelectMenuFixture();
+    const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+    const trigger = dropdown.querySelector('[slot="trigger"]');
+
+    trigger.click();
+    await elementUpdated(el);
+
+    // Navigate to the first option
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    await elementUpdated(el);
+    expect(el.menu.optionActive.value).to.equal('stops');
+
+    // ArrowUp from first should wrap to departure (last option)
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' }));
+    await elementUpdated(el);
+    expect(el.menu.optionActive.value).to.equal('departure');
+  });
+});
+
+// ─── Nested menu selection behavior ──────────────────────────────────────────
+
+async function nestedMixedSelectFixture() {
+  return await fixture(html`
+    <auro-select>
+      <span slot="label">Sort by</span>
+      <auro-menu>
+        <auro-menuoption value="stops">Stops</auro-menuoption>
+        <auro-menuoption value="price">Price</auro-menuoption>
+        <auro-menu>
+          <auro-menuoption value="apples">Apples</auro-menuoption>
+          <auro-menuoption value="oranges">Oranges</auro-menuoption>
+        </auro-menu>
+        <auro-menuoption value="departure">Departure</auro-menuoption>
+      </auro-menu>
+    </auro-select>
+  `);
+}
+
+async function nestedMultiselectFixture() {
+  return await fixture(html`
+    <auro-select multiselect>
+      <span slot="label">Sort by</span>
+      <auro-menu>
+        <auro-menuoption value="stops">Stops</auro-menuoption>
+        <auro-menuoption value="price">Price</auro-menuoption>
+        <auro-menu>
+          <auro-menuoption value="apples">Apples</auro-menuoption>
+          <auro-menuoption value="oranges">Oranges</auro-menuoption>
+        </auro-menu>
+      </auro-menu>
+    </auro-select>
+  `);
+}
+
+describe('nested menu selection behavior (single-select)', () => {
+  it('selecting a nested option then a top-level option leaves only one selection', async () => {
+    await setScreenSize(false);
+    const el = await nestedMixedSelectFixture();
+    const menu = el.querySelector('auro-menu');
+    const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+    const trigger = dropdown.querySelector('[slot="trigger"]');
+
+    // Use programmatic value to pre-select the nested option without touching
+    // optionActive. Keyboard-nav then select-Enter would leave optionActive
+    // pointing at apples, causing ArrowDown counts to shift on reopen.
+    el.value = 'apples';
+    await elementUpdated(el);
+    await elementUpdated(menu);
+
+    expect(el.value).to.equal('apples');
+    expect(el.optionSelected?.value).to.equal('apples');
+
+    // Open and navigate to stops from clean null-active state
+    trigger.click();
+    await elementUpdated(el);
+
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    await elementUpdated(el);
+    expect(el.menu.optionActive.value).to.equal('stops');
+
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    await elementUpdated(el);
+
+    expect(el.value).to.equal('stops');
+    expect(el.optionSelected?.value).to.equal('stops');
+
+    // Only one option must hold the selected state — the new selection
+    const selectedOptions = [...el.querySelectorAll('auro-menuoption')].filter(
+      (option) => option.selected
+    );
+    expect(selectedOptions.length).to.equal(1);
+    expect(selectedOptions[0].value).to.equal('stops');
+  });
+
+  it('selecting a top-level option then a nested option leaves only one selection', async () => {
+    await setScreenSize(false);
+    const el = await nestedMixedSelectFixture();
+    const menu = el.querySelector('auro-menu');
+    const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+    const trigger = dropdown.querySelector('[slot="trigger"]');
+
+    el.value = 'stops';
+    await elementUpdated(el);
+    await elementUpdated(menu);
+
+    expect(el.value).to.equal('stops');
+
+    trigger.click();
+    await elementUpdated(el);
+
+    // 3 ArrowDowns from null active → stops(1) → price(2) → apples(3)
+    for (let i = 0; i < 3; i++) {
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      await elementUpdated(el);
+    }
+    expect(el.menu.optionActive.value).to.equal('apples');
+
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    await elementUpdated(el);
+
+    expect(el.value).to.equal('apples');
+    expect(el.optionSelected?.value).to.equal('apples');
+
+    const selectedOptions = [...el.querySelectorAll('auro-menuoption')].filter(
+      (option) => option.selected
+    );
+    expect(selectedOptions.length).to.equal(1);
+    expect(selectedOptions[0].value).to.equal('apples');
+  });
+
+  it('programmatic nested selection then reopen and navigate to main option cleanly', async () => {
+    await setScreenSize(false);
+    const el = await nestedMixedSelectFixture();
+    const menu = el.querySelector('auro-menu');
+    const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+    const trigger = dropdown.querySelector('[slot="trigger"]');
+
+    el.value = 'apples';
+    await elementUpdated(el);
+    await elementUpdated(menu);
+
+    expect(el.value).to.equal('apples');
+    expect(el.isPopoverVisible).to.be.false;
+
+    trigger.click();
+    await elementUpdated(el);
+    expect(el.isPopoverVisible).to.be.true;
+
+    // From null active state: 1 ArrowDown → stops
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    await elementUpdated(el);
+    expect(el.menu.optionActive.value).to.equal('stops');
+
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    await elementUpdated(el);
+
+    expect(el.value).to.equal('stops');
+    expect(el.optionSelected?.value).to.equal('stops');
+    expect(el.isPopoverVisible).to.be.false;
+  });
+
+  it('selecting main option then nested via keyboard leaves only nested selected', async () => {
+    await setScreenSize(false);
+    const el = await nestedMixedSelectFixture();
+    const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+    const trigger = dropdown.querySelector('[slot="trigger"]');
+
+    trigger.click();
+    await elementUpdated(el);
+
+    // 1x ArrowDown → stops; Enter selects and closes bib
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    await elementUpdated(el);
+    expect(el.menu.optionActive.value).to.equal('stops');
+
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    await elementUpdated(el);
+
+    expect(el.value).to.equal('stops');
+    expect(el.isPopoverVisible).to.be.false;
+
+    trigger.click();
+    await elementUpdated(el);
+
+    // 3x ArrowDown → apples (nested); Enter selects apples
+    for (let i = 0; i < 3; i++) {
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      await elementUpdated(el);
+    }
+    expect(el.menu.optionActive.value).to.equal('apples');
+
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    await elementUpdated(el);
+
+    expect(el.value).to.equal('apples');
+    expect(el.optionSelected?.value).to.equal('apples');
+
+    // Only apples should be selected — guards against the dual-selection bug
+    const selectedOptions = [...el.querySelectorAll('auro-menuoption')].filter(
+      (option) => option.selected
+    );
+    expect(selectedOptions.length).to.equal(1);
+    expect(selectedOptions[0].value).to.equal('apples');
+  });
+
+  it('pure keyboard: selecting nested then main leaves only main selected', async () => {
+    await setScreenSize(false);
+    const el = await nestedMixedSelectFixture();
+    const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+    const trigger = dropdown.querySelector('[slot="trigger"]');
+
+    trigger.click();
+    await elementUpdated(el);
+
+    // 3x ArrowDown → apples (nested); Enter selects apples
+    for (let i = 0; i < 3; i++) {
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      await elementUpdated(el);
+    }
+    expect(el.menu.optionActive.value).to.equal('apples');
+
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    await elementUpdated(el);
+
+    expect(el.value).to.equal('apples');
+    expect(el.isPopoverVisible).to.be.false;
+
+    trigger.click();
+    await elementUpdated(el);
+
+    // 1x ArrowDown → stops; Enter selects stops
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    await elementUpdated(el);
+    expect(el.menu.optionActive.value).to.equal('stops');
+
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    await elementUpdated(el);
+
+    expect(el.value).to.equal('stops');
+    expect(el.optionSelected?.value).to.equal('stops');
+
+    // Only stops should be selected — guards against the dual-selection bug
+    const selectedOptions = [...el.querySelectorAll('auro-menuoption')].filter(
+      (option) => option.selected
+    );
+    expect(selectedOptions.length).to.equal(1);
+    expect(selectedOptions[0].value).to.equal('stops');
+  });
+});
+
+describe('nested menu selection behavior (multiselect)', () => {
+  it('can select both a nested option and a top-level option simultaneously', async () => {
+    await setScreenSize(false);
+    const el = await nestedMultiselectFixture();
+    const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+    const trigger = dropdown.querySelector('[slot="trigger"]');
+
+    trigger.click();
+    await elementUpdated(el);
+
+    // Select stops (first ArrowDown)
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    await elementUpdated(el);
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    await elementUpdated(el);
+
+    // Reopen and select apples (nested)
+    trigger.click();
+    await elementUpdated(el);
+
+    for (let i = 0; i < 3; i++) {
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      await elementUpdated(el);
+    }
+    expect(el.menu.optionActive.value).to.equal('apples');
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    await elementUpdated(el);
+
+    const parsed = JSON.parse(el.value);
+    expect(parsed).to.include('stops');
+    expect(parsed).to.include('apples');
+    expect(Array.isArray(el.optionSelected)).to.be.true;
+    expect(el.optionSelected.length).to.equal(2);
+  });
+
+  it('Tab closes multiselect without making a selection when bib is open', async () => {
+    await setScreenSize(false);
+    const el = await nestedMultiselectFixture();
+    const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+    const trigger = dropdown.querySelector('[slot="trigger"]');
+
+    trigger.click();
+    await elementUpdated(el);
+
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    await elementUpdated(el);
+    expect(el.menu.optionActive.value).to.equal('stops');
+
+    // Tab on multiselect should close without selecting
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
+    await elementUpdated(el);
+
+    expect(el.isPopoverVisible).to.be.false;
+    expect(el.value).to.be.undefined;
+  });
+
+  it('deselecting a nested option in multiselect removes it from value', async () => {
+    await setScreenSize(false);
+    const el = await nestedMultiselectFixture();
+    const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+    const trigger = dropdown.querySelector('[slot="trigger"]');
+
+    trigger.click();
+    await elementUpdated(el);
+
+    // 3x ArrowDown → apples (nested); Enter selects
+    for (let i = 0; i < 3; i++) {
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      await elementUpdated(el);
+    }
+    expect(el.menu.optionActive.value).to.equal('apples');
+
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    await elementUpdated(el);
+
+    const applesOption = el.querySelector('auro-menuoption[value="apples"]');
+    expect(applesOption.selected).to.be.true;
+
+    // Reopen and navigate back to apples to deselect it
+    trigger.click();
+    await elementUpdated(el);
+
+    for (let i = 0; i < 3; i++) {
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      await elementUpdated(el);
+    }
+    expect(el.menu.optionActive.value).to.equal('apples');
+
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    await elementUpdated(el);
+
+    expect(applesOption.selected).to.be.false;
+    expect(el.value).to.be.undefined;
+  });
+
+  it('keyboard selects nested and main options in multiselect simultaneously', async () => {
+    await setScreenSize(false);
+    const el = await nestedMultiselectFixture();
+    const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+    const trigger = dropdown.querySelector('[slot="trigger"]');
+
+    trigger.click();
+    await elementUpdated(el);
+
+    // 3x ArrowDown → apples (nested); Enter selects
+    for (let i = 0; i < 3; i++) {
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      await elementUpdated(el);
+    }
+    expect(el.menu.optionActive.value).to.equal('apples');
+
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    await elementUpdated(el);
+
+    // Reopen and keyboard-select stops (main)
+    trigger.click();
+    await elementUpdated(el);
+
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    await elementUpdated(el);
+    expect(el.menu.optionActive.value).to.equal('stops');
+
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    await elementUpdated(el);
+
+    const parsed = JSON.parse(el.value);
+    expect(parsed).to.include('apples');
+    expect(parsed).to.include('stops');
+    expect(Array.isArray(el.optionSelected)).to.be.true;
+    expect(el.optionSelected.length).to.equal(2);
+  });
+});


### PR DESCRIPTION
# Alaska Airlines Pull Request

Enhance keyboard navigation for nested menus and improve highlight management

## Review Checklist:

- [ ] My update follows the CONTRIBUTING guidelines of this project
- [ ] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Improve nested menu keyboard navigation and selection behavior across auro-menu, auro-select, and auro-combobox, ensuring consistent highlighting and selection for nested options.

Bug Fixes:
- Fix keyboard navigation so ArrowUp/ArrowDown correctly traverse nested auro-menu options in DOM order for select and combobox, including wrap and reverse navigation.
- Ensure single-select components never leave both a top-level and nested option selected simultaneously when changing selections.
- Preserve correct highlighted state and active CSS classes when moving between options managed by different MenuService instances, including nested menus.
- Ensure programmatic or keyboard-driven selection of nested options properly updates selected state and value casing without leaving stale highlights or offsets on reopen.
- Allow typeahead/pending value resolution to correctly select nested menu options that were previously ignored due to context isolation.

Enhancements:
- Extend MenuService to track the highlighted option by reference, flatten active options across nested menus, and synchronize selected state to nested options.
- Add explicit APIs to clear menu highlight state and invoke them when select and combobox dropdowns close to start navigation from a clean state.
- Refine Storybook coverage for select, combobox, and menu to focus on realistic nested menu scenarios and add chromatic-enabled stories for regression coverage of nested interactions.

Tests:
- Add comprehensive unit tests for auro-select nested menu keyboard navigation, wrapping behavior, and single- vs multi-select selection rules.
- Add extensive unit tests for auro-combobox nested menu behavior on desktop and fullscreen, including navigation, case preservation, reopen flows, and selection exclusivity.
- Add Storybook interaction tests for nested select and combobox scenarios, including keyboard navigation, enter-to-select flows, mixed single/multiselect interactions, and deselection behavior.
- Remove or replace older menu keyboard navigation stories in favor of more targeted nested-menu-focused coverage.