### PR TITLE
perf(dropdown): remove keyboardBridge

### DIFF
--- a/components/datepicker/src/auro-datepicker.js
+++ b/components/datepicker/src/auro-datepicker.js
@@ -1944,7 +1944,6 @@ export class AuroDatePicker extends AuroElement {
           .size="${this.size}"
           class="${classMap(dropdownElementClassMap)}"
           disableEventShow
-          disableFocusTrap
           for="dropdownMenu"
           part="dropdown"
         >

--- a/components/dropdown/docs/api.md
+++ b/components/dropdown/docs/api.md
@@ -11,7 +11,6 @@ The `auro-dropdown` element provides a way to place content in a bib that can be
 | `autoPlacement`         | `autoPlacement`         | `boolean`                                        |                  | If declared, bib's position will be automatically calculated where to appear. |
 | `chevron`               | `chevron`               | `boolean`                                        |                  | If declared, the dropdown displays a chevron on the right. |
 | `disableEventShow`      | `disableEventShow`      | `boolean`                                        |                  | If declared, the dropdown will only show by calling the API .show() public method. |
-| `disableFocusTrap`      | `disableFocusTrap`      | `boolean`                                        |                  | If declared, the focus trap inside of bib will be turned off. |
 | `disabled`              | `disabled`              | `boolean`                                        |                  | If declared, the dropdown is not interactive.    |
 | `error`                 | `error`                 | `boolean`                                        |                  | If declared, will apply error UI to the dropdown. |
 | `errorMessage`          | `errorMessage`          | `string`                                         | "undefined"      | Contains the help text message for the current validity error. |

--- a/components/dropdown/src/auro-dropdown.js
+++ b/components/dropdown/src/auro-dropdown.js
@@ -110,7 +110,6 @@ export class AuroDropdown extends AuroElement {
     this.appearance = 'default';
     this.chevron = false;
     this.disabled = false;
-    this.disableFocusTrap = true;
     this.error = false;
     this.tabIndex = 0;
     this.noToggle = false;
@@ -208,9 +207,8 @@ export class AuroDropdown extends AuroElement {
     // showModal() fires asynchronously via Lit's update cycle, which
     // falls outside the user activation window and causes iOS to
     // dismiss the keyboard.
-    if (this.isBibFullscreen && this.bibElement && this.bibElement.value) {
-      const useModal = !this.disableFocusTrap;
-      this.bibElement.value.open(useModal);
+    if (this.bibElement && this.bibElement.value) {
+      this.bibElement.value.open(this.isBibFullscreen);
     }
   }
 
@@ -319,14 +317,6 @@ export class AuroDropdown extends AuroElement {
        * If declared, the dropdown is not interactive.
        */
       disabled: {
-        type: Boolean,
-        reflect: true
-      },
-
-      /**
-       * If declared, the focus trap inside of bib will be turned off.
-       */
-      disableFocusTrap: {
         type: Boolean,
         reflect: true
       },
@@ -604,7 +594,7 @@ export class AuroDropdown extends AuroElement {
       if (this.isPopoverVisible) {
         // Fullscreen: use showModal() for native accessibility (inert outside, focus trap)
         // Desktop: use show() for Floating UI positioning + FocusTrap for focus management
-        const useModal = this.isBibFullscreen && !this.disableFocusTrap;
+        const useModal = this.isBibFullscreen;
         this.bibElement.value.open(useModal);
       } else {
         this.bibElement.value.close();
@@ -614,7 +604,7 @@ export class AuroDropdown extends AuroElement {
     // When fullscreen strategy changes while open, re-open dialog with correct mode
     // (e.g. resizing from desktop → mobile while dropdown is open)
     if (changedProperties.has('isBibFullscreen') && this.isPopoverVisible && this.bibElement.value) {
-      const useModal = this.isBibFullscreen && !this.disableFocusTrap;
+      const useModal = this.isBibFullscreen;
       this.bibElement.value.close();
       this.bibElement.value.open(useModal);
     }
@@ -728,7 +718,7 @@ export class AuroDropdown extends AuroElement {
    * @private
    */
   updateFocusTrap() {
-    if (this.isPopoverVisible && !this.disableFocusTrap) {
+    if (this.isPopoverVisible) {
       if (!this.isBibFullscreen) {
         // Desktop: show() doesn't trap focus, so use FocusTrap
         this.focusTrap = new FocusTrap(this.bibContent);

--- a/components/dropdown/src/auro-dropdown.js
+++ b/components/dropdown/src/auro-dropdown.js
@@ -110,7 +110,7 @@ export class AuroDropdown extends AuroElement {
     this.appearance = 'default';
     this.chevron = false;
     this.disabled = false;
-    this.disableFocusTrap = false;
+    this.disableFocusTrap = true;
     this.error = false;
     this.tabIndex = 0;
     this.noToggle = false;

--- a/components/dropdown/src/auro-dropdownBib.js
+++ b/components/dropdown/src/auro-dropdownBib.js
@@ -11,10 +11,12 @@ import { classMap } from 'lit/directives/class-map.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 
 import AuroLibraryRuntimeUtils from '@aurodesignsystem/auro-library/scripts/utils/runtimeUtils.mjs';
+import { applyKeyboardStrategy } from '@aurodesignsystem/utils';
 
 import styleCss from "./styles/classic/bibStyles-css.js";
 import colorCss from "./styles/classic/bibColors-css.js";
 import tokensCss from "./styles/tokens-css.js";
+import { createDropdownBibKeyboardStrategy } from './dropdownBibKeyboardStrategy.js';
 
 const DESIGN_TOKEN_BREAKPOINT_PREFIX = '--ds-grid-breakpoint-';
 const DESIGN_TOKEN_BREAKPOINT_OPTIONS = [
@@ -134,11 +136,7 @@ export class AuroDropdownBib extends LitElement {
       },
 
       /**
-       * Set by auro-dropdown when a menu option is highlighted via
-       * aria-activedescendant. The dialog keyboard bridge checks this
-       * flag so that Enter selects the highlighted option instead of
-       * activating the focused interactive element (e.g. the trigger
-       * button, or the bibtemplate close button in fullscreen).
+       * Tracks whether a menu option is currently highlighted.
        * @private
        */
       hasActiveDescendant: {
@@ -212,7 +210,7 @@ export class AuroDropdownBib extends LitElement {
 
     const dialog = this.shadowRoot.querySelector('dialog');
     this._setupCancelHandler(dialog);
-    this._setupKeyboardBridge(dialog);
+    applyKeyboardStrategy(dialog, createDropdownBibKeyboardStrategy(this));
 
     this.dispatchEvent(new CustomEvent('auro-dropdownbib-connected', {
       bubbles: true,
@@ -239,92 +237,6 @@ export class AuroDropdownBib extends LitElement {
     });
   }
 
-  /**
-   * showModal() creates a closed focus scope — keyboard events inside
-   * the dialog's shadow DOM do NOT bubble out to the combobox/select
-   * keydown handlers in the parent shadow DOM. This handler bridges
-   * that gap by re-dispatching navigation keys so they cross the
-   * shadow boundary and reach the menu navigation logic in the parent
-   * component.
-   *
-   * The trade-off: intercepting these keys means native keyboard
-   * behaviors that would normally "just work" must be manually
-   * re-implemented here:
-   *
-   * - Enter on buttons: Custom elements (auro-button) don't get the
-   *   native Enter→click that <button> provides, so we call .click()
-   *   directly when Enter is pressed on a button-like element.
-   *
-   * - Tab: Intercepted and re-dispatched so parent components
-   *   (select/combobox) can select the active option and close the
-   *   dialog. The <dialog> provides containment and isolation
-   *   (inert background, VoiceOver focus trapping, top layer), while
-   *   the content inside is a role="listbox" navigated via
-   *   aria-activedescendant (options are not focusable). Tab keyboard
-   *   behavior follows listbox conventions (select + close) because
-   *   the dialog's native Tab trap only cycles between the close
-   *   button and browser chrome.
-   *
-   * - Escape: The native <dialog> fires a `cancel` event on ESC
-   *   (handled by _setupCancelHandler), so the re-dispatched Escape
-   *   is a secondary path for parent components that also listen for
-   *   Escape keydown.
-   *
-   * @param {HTMLDialogElement} dialog - The dialog element to attach the keyboard bridge to.
-   * @private
-   */
-  _setupKeyboardBridge(dialog) {
-    const navKeys = new Set([
-      'ArrowUp',
-      'ArrowDown',
-      'Enter',
-      'Escape',
-      'Tab'
-    ]);
-
-    dialog.addEventListener('keydown', (event) => {
-      if (!navKeys.has(event.key)) {
-        return;
-      }
-
-      // Custom elements (auro-button) don't get the native Enter→click
-      // behavior that <button> has. Find the button in the composed path
-      // and click it directly — but only when no menu option is
-      // highlighted. In fullscreen mode focus stays on the close button
-      // while arrow keys move the active-descendant highlight through
-      // the listbox. If the user presses Enter with an option
-      // highlighted, the intent is to select that option, not to click
-      // the close button. In that case we fall through and bridge the
-      // Enter key to the parent component's keyboard strategy.
-      if (event.key === 'Enter') {
-        if (!this.hasActiveDescendant) {
-          const buttonSelector = 'button, [role="button"], auro-button, [auro-button]';
-          const btn = event.composedPath().find((el) => el.matches && el.matches(buttonSelector));
-          if (btn) {
-            event.preventDefault();
-            event.stopPropagation();
-            btn.click();
-            return;
-          }
-        }
-      }
-
-      event.preventDefault();
-      event.stopPropagation();
-      const newEvent = new KeyboardEvent('keydown', {
-        key: event.key,
-        code: event.code,
-        shiftKey: event.shiftKey,
-        altKey: event.altKey,
-        ctrlKey: event.ctrlKey,
-        metaKey: event.metaKey,
-        bubbles: true,
-        composed: true,
-        cancelable: true
-      });
-      this.dispatchEvent(newEvent);
-    });
-  }
 
   /**
    * Blocks touch-driven page scroll while a fullscreen modal dialog is open.

--- a/components/dropdown/src/dropdownBibKeyboardStrategy.js
+++ b/components/dropdown/src/dropdownBibKeyboardStrategy.js
@@ -4,11 +4,14 @@
  * @param {HTMLElement} bib - The dropdown bib element.
  * @returns {Object} Keyboard handlers keyed by `event.key`.
  */
+// eslint-disable-next-line no-unused-vars
 export function createDropdownBibKeyboardStrategy(bib) {
   return {
+    // eslint-disable-next-line no-unused-vars
     Enter(_dialog, event) {
       // Floating UI handles Enter key to open the dropdown
     },
+    // eslint-disable-next-line no-unused-vars
     Escape(_dialog, event) {
       // Floating UI handles Escape key to close the dropdown
     }

--- a/components/dropdown/src/dropdownBibKeyboardStrategy.js
+++ b/components/dropdown/src/dropdownBibKeyboardStrategy.js
@@ -1,0 +1,16 @@
+/**
+ * Creates a keyboard strategy for dialog-specific key handling.
+ * All other keydown behavior is left to the browser's native bubbling path.
+ * @param {HTMLElement} bib - The dropdown bib element.
+ * @returns {Object} Keyboard handlers keyed by `event.key`.
+ */
+export function createDropdownBibKeyboardStrategy(bib) {
+  return {
+    Enter(_dialog, event) {
+      // Floating UI handles Enter key to open the dropdown
+    },
+    Escape(_dialog, event) {
+      // Floating UI handles Escape key to close the dropdown
+    }
+  };
+}

--- a/components/dropdown/test/auro-dropdown.test.js
+++ b/components/dropdown/test/auro-dropdown.test.js
@@ -413,58 +413,6 @@ describe("auro-dropdown", () => {
     expectPopoverHidden(el);
   });
 
-  describe("dialog keyboard bridge", () => {
-    async function openFullscreenDropdown() {
-      const el = await fixture(html`
-        <auro-dropdown>
-          <span slot="label"> label text </span>
-          <div slot="trigger">Trigger</div>
-        </auro-dropdown>
-      `);
-
-      el.isBibFullscreen = true;
-      el.show();
-      await elementUpdated(el);
-
-      const bibEl = el.bibElement.value;
-      const dialog = bibEl.shadowRoot.querySelector('dialog');
-
-      return { el, bibEl, dialog };
-    }
-
-    for (const key of ['ArrowUp', 'ArrowDown', 'Escape', 'Tab']) {
-      it(`re-dispatches ${key} from dialog to parent`, async () => {
-        const { el, dialog } = await openFullscreenDropdown();
-
-        const received = [];
-        el.addEventListener('keydown', (e) => received.push(e.key));
-
-        dialog.dispatchEvent(new KeyboardEvent('keydown', {
-          key,
-          bubbles: true,
-          cancelable: true
-        }));
-
-        expect(received.filter((k) => k === key)).to.have.lengthOf(1);
-      });
-    }
-
-    it('does not re-dispatch non-navigation keys to parent', async () => {
-      const { el, dialog } = await openFullscreenDropdown();
-
-      const received = [];
-      el.addEventListener('keydown', (e) => received.push(e.key));
-
-      dialog.dispatchEvent(new KeyboardEvent('keydown', {
-        key: 'a',
-        bubbles: true,
-        cancelable: true
-      }));
-
-      expect(received).to.deep.equal([]);
-    });
-  });
-
   it("auro-dropdown renders with emphasized layout", async () => {
     const el = await fixture(html`
       <auro-dropdown layout="emphasized" shape="pill">


### PR DESCRIPTION
# Alaska Airlines Pull Request

remove keyboardbridge


!!! the test might fail !!!

## Review Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Simplify dropdown bib keyboard handling by replacing the custom keyboard bridge with a reusable keyboard strategy and adjusting focus behavior defaults.

Enhancements:
- Replace the internal keyboard bridge in the dropdown bib dialog with a shared keyboard strategy utility for Enter and Escape handling.
- Add a dedicated dropdown bib keyboard strategy module to integrate with the common keyboard strategy infrastructure.
- Introduce a flag to track whether the dropdown bib contains native focusable content and update the default to disable the focus trap in the main dropdown component.