### PR TITLE
fix(select): add Home/End key handlers

### DIFF
--- a/components/dropdown/docs/api.md
+++ b/components/dropdown/docs/api.md
@@ -4,34 +4,35 @@ The `auro-dropdown` element provides a way to place content in a bib that can be
 
 ## Properties
 
-| Property                | Attribute               | Type                                             | Default          | Description                                      |
-|-------------------------|-------------------------|--------------------------------------------------|------------------|--------------------------------------------------|
-| `a11yRole`              |                         | `string`                                         |                  | The value for the role attribute of the trigger element. |
-| `appearance`            | `appearance`            | `'default' \| 'inverse'`                         | "'default'"      | Defines whether the component will be on lighter or darker backgrounds. |
-| `autoPlacement`         | `autoPlacement`         | `boolean`                                        |                  | If declared, bib's position will be automatically calculated where to appear. |
-| `chevron`               | `chevron`               | `boolean`                                        |                  | If declared, the dropdown displays a chevron on the right. |
-| `disableEventShow`      | `disableEventShow`      | `boolean`                                        |                  | If declared, the dropdown will only show by calling the API .show() public method. |
-| `disabled`              | `disabled`              | `boolean`                                        |                  | If declared, the dropdown is not interactive.    |
-| `error`                 | `error`                 | `boolean`                                        |                  | If declared, will apply error UI to the dropdown. |
-| `errorMessage`          | `errorMessage`          | `string`                                         | "undefined"      | Contains the help text message for the current validity error. |
-| `focusShow`             | `focusShow`             | `boolean`                                        |                  | If declared, the bib will display when focus is applied to the trigger. |
-| `fullscreenBreakpoint`  | `fullscreenBreakpoint`  | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| 'disabled'` | "'sm'"           | Defines the screen size breakpoint at which the dropdown switches to fullscreen mode on mobile. `disabled` indicates a dropdown should _never_ enter fullscreen.<br /><br />When expanded, the dropdown will automatically display in fullscreen mode<br />if the screen size is equal to or smaller than the selected breakpoint. |
-| `hoverToggle`           | `hoverToggle`           | `boolean`                                        |                  | If declared, the trigger will toggle the dropdown on mouseover/mouseout. |
-| `isBibFullscreen`       | `isBibFullscreen`       | `boolean`                                        | false            | If true, the dropdown bib is taking the fullscreen when it's open. |
-| `isPopoverVisible`      | `open`                  | `boolean`                                        | false            | If true, the dropdown bib is displayed.          |
-| `layout`                | `layout`                | `'classic' \| 'emphasized' \| 'snowflake'`       | "'classic'"      | Sets the layout of the dropdown.                 |
-| `matchWidth`            | `matchWidth`            | `boolean`                                        | false            | If declared, the popover and trigger will be set to the same width. |
-| `noFlip`                | `noFlip`                | `boolean`                                        |                  | If declared, the bib will NOT flip to an alternate position<br />when there isn't enough space in the specified `placement`. |
-| `noHideOnThisFocusLoss` | `noHideOnThisFocusLoss` | `boolean`                                        | false            | If declared, the dropdown will not hide when moving focus outside the element. |
-| `noToggle`              | `noToggle`              | `boolean`                                        |                  | If declared, the trigger will only show the dropdown bib. |
-| `offset`                | `offset`                | `number`                                         | "0"              | Gap between the trigger element and bib.         |
-| `onDark`                | `onDark`                | `boolean`                                        |                  | DEPRECATED - use `appearance="inverse"` instead. |
-| `onSlotChange`          | `onSlotChange`          |                                                  |                  | If declared, and a function is set, that function will execute when the slot content is updated. |
-| `placement`             | `placement`             | `'top' \| 'right' \| 'bottom' \| 'left' \| 'bottom-start' \| 'top-start' \| 'top-end' \| 'right-start' \| 'right-end' \| 'bottom-end' \| 'left-start' \| 'left-end'` | "'bottom-start'" | Position where the bib should appear relative to the trigger. |
-| `shape`                 |                         |                                                  | "undefined"      |                                                  |
-| `shift`                 | `shift`                 | `boolean`                                        |                  | If declared, the dropdown will shift its position to avoid being cut off by the viewport. |
-| `simple`                | `simple`                | `boolean`                                        |                  | If declared, applies a border around the trigger slot. |
-| `size`                  |                         |                                                  | "undefined"      |                                                  |
+| Property                  | Attribute                 | Type                                             | Default          | Description                                      |
+|---------------------------|---------------------------|--------------------------------------------------|------------------|--------------------------------------------------|
+| `a11yRole`                |                           | `string`                                         |                  | The value for the role attribute of the trigger element. |
+| `appearance`              | `appearance`              | `'default' \| 'inverse'`                         | "'default'"      | Defines whether the component will be on lighter or darker backgrounds. |
+| `autoPlacement`           | `autoPlacement`           | `boolean`                                        |                  | If declared, bib's position will be automatically calculated where to appear. |
+| `chevron`                 | `chevron`                 | `boolean`                                        |                  | If declared, the dropdown displays a chevron on the right. |
+| `disableEventShow`        | `disableEventShow`        | `boolean`                                        |                  | If declared, the dropdown will only show by calling the API .show() public method. |
+| `disableKeyboardHandling` | `disableKeyboardHandling` | `boolean`                                        |                  | If declared, the dropdown will not handle keyboard events and will require the consumer to manage this behavior. |
+| `disabled`                | `disabled`                | `boolean`                                        |                  | If declared, the dropdown is not interactive.    |
+| `error`                   | `error`                   | `boolean`                                        |                  | If declared, will apply error UI to the dropdown. |
+| `errorMessage`            | `errorMessage`            | `string`                                         | "undefined"      | Contains the help text message for the current validity error. |
+| `focusShow`               | `focusShow`               | `boolean`                                        |                  | If declared, the bib will display when focus is applied to the trigger. |
+| `fullscreenBreakpoint`    | `fullscreenBreakpoint`    | `'xs' \| 'sm' \| 'md' \| 'lg' \| 'xl' \| 'disabled'` | "'sm'"           | Defines the screen size breakpoint at which the dropdown switches to fullscreen mode on mobile. `disabled` indicates a dropdown should _never_ enter fullscreen.<br /><br />When expanded, the dropdown will automatically display in fullscreen mode<br />if the screen size is equal to or smaller than the selected breakpoint. |
+| `hoverToggle`             | `hoverToggle`             | `boolean`                                        |                  | If declared, the trigger will toggle the dropdown on mouseover/mouseout. |
+| `isBibFullscreen`         | `isBibFullscreen`         | `boolean`                                        | false            | If true, the dropdown bib is taking the fullscreen when it's open. |
+| `isPopoverVisible`        | `open`                    | `boolean`                                        | false            | If true, the dropdown bib is displayed.          |
+| `layout`                  | `layout`                  | `'classic' \| 'emphasized' \| 'snowflake'`       | "'classic'"      | Sets the layout of the dropdown.                 |
+| `matchWidth`              | `matchWidth`              | `boolean`                                        | false            | If declared, the popover and trigger will be set to the same width. |
+| `noFlip`                  | `noFlip`                  | `boolean`                                        |                  | If declared, the bib will NOT flip to an alternate position<br />when there isn't enough space in the specified `placement`. |
+| `noHideOnThisFocusLoss`   | `noHideOnThisFocusLoss`   | `boolean`                                        | false            | If declared, the dropdown will not hide when moving focus outside the element. |
+| `noToggle`                | `noToggle`                | `boolean`                                        |                  | If declared, the trigger will only show the dropdown bib. |
+| `offset`                  | `offset`                  | `number`                                         | "0"              | Gap between the trigger element and bib.         |
+| `onDark`                  | `onDark`                  | `boolean`                                        |                  | DEPRECATED - use `appearance="inverse"` instead. |
+| `onSlotChange`            | `onSlotChange`            |                                                  |                  | If declared, and a function is set, that function will execute when the slot content is updated. |
+| `placement`               | `placement`               | `'top' \| 'right' \| 'bottom' \| 'left' \| 'bottom-start' \| 'top-start' \| 'top-end' \| 'right-start' \| 'right-end' \| 'bottom-end' \| 'left-start' \| 'left-end'` | "'bottom-start'" | Position where the bib should appear relative to the trigger. |
+| `shape`                   |                           |                                                  | "undefined"      |                                                  |
+| `shift`                   | `shift`                   | `boolean`                                        |                  | If declared, the dropdown will shift its position to avoid being cut off by the viewport. |
+| `simple`                  | `simple`                  | `boolean`                                        |                  | If declared, applies a border around the trigger slot. |
+| `size`                    |                           |                                                  | "undefined"      |                                                  |
 
 ## Methods
 

--- a/components/dropdown/src/auro-dropdown.js
+++ b/components/dropdown/src/auro-dropdown.js
@@ -945,6 +945,7 @@ export class AuroDropdown extends AuroElement {
           aria-expanded="${ifDefined(this.a11yRole === 'button' || this.triggerContentFocusable ? undefined : this.isPopoverVisible)}"
           aria-controls="${ifDefined(this.a11yRole === 'button' || this.triggerContentFocusable ? undefined : this.dropdownId)}"
           aria-labelledby="${ifDefined(this.triggerContentFocusable ? undefined : 'triggerLabel')}"
+          aria-disabled="${ifDefined(this.disabled ? 'true' : undefined)}"
           @focusin="${this.handleFocusin}"
           @blur="${this.handleFocusOut}">
           <div class="triggerContentWrapper" id="triggerLabel">

--- a/components/dropdown/src/auro-dropdown.js
+++ b/components/dropdown/src/auro-dropdown.js
@@ -110,6 +110,7 @@ export class AuroDropdown extends AuroElement {
     this.appearance = 'default';
     this.chevron = false;
     this.disabled = false;
+    this.disableKeyboardHandling = false;
     this.error = false;
     this.tabIndex = 0;
     this.noToggle = false;
@@ -317,6 +318,14 @@ export class AuroDropdown extends AuroElement {
        * If declared, the dropdown is not interactive.
        */
       disabled: {
+        type: Boolean,
+        reflect: true
+      },
+
+      /**
+       * If declared, the dropdown will not handle keyboard events and will require the consumer to manage this behavior.
+       */
+      disableKeyboardHandling: {
         type: Boolean,
         reflect: true
       },
@@ -626,7 +635,7 @@ export class AuroDropdown extends AuroElement {
 
   firstUpdated() {
     // Configure the floater to, this will generate the ID for the bib
-    this.floater.configure(this, 'auroDropdown');
+    this.floater.configure(this, 'auroDropdown', !this.disableKeyboardHandling);
 
     // Prevent `contain: layout` on the dropdown host. Layout containment
     // creates a containing block for position:fixed descendants (the bib),

--- a/components/dropdown/test/auro-dropdown.test.js
+++ b/components/dropdown/test/auro-dropdown.test.js
@@ -130,6 +130,21 @@ describe("auro-dropdown", () => {
     expectPopoverHidden(el);
   });
 
+  it("auro-dropdown does not open when disabled and clicked", async () => {
+    const el = await fixture(html`
+      <auro-dropdown disabled>
+        <span slot="label"> label text </span>
+        <div slot="trigger">Trigger</div>
+      </auro-dropdown>
+    `);
+
+    const trigger = el.shadowRoot.querySelector("#trigger");
+    expectPopoverHidden(el);
+
+    trigger.click();
+    expectPopoverHidden(el);
+  });
+
   it("auro-dropdown programmatically hide", async () => {
     const el = await fixture(html`
       <auro-dropdown toggle chevron>
@@ -282,6 +297,24 @@ describe("auro-dropdown", () => {
     );
 
     expectPopoverShown(el);
+  });
+
+  it("auro-dropdown does not open with keyboard when disableKeyboardHandling is set", async () => {
+    const el = await fixture(html`
+      <auro-dropdown disableKeyboardHandling>
+        <span slot="label"> label text </span>
+        <div slot="trigger">Trigger</div>
+      </auro-dropdown>
+    `);
+
+    const trigger = el.shadowRoot.querySelector("#trigger");
+    expectPopoverHidden(el);
+
+    trigger.dispatchEvent(new KeyboardEvent("keydown", { key: " " }));
+    expectPopoverHidden(el);
+
+    trigger.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
+    expectPopoverHidden(el);
   });
 
   it("auro-dropdown hides with `Escape` key", async () => {

--- a/components/menu/src/auro-menuoption.js
+++ b/components/menu/src/auro-menuoption.js
@@ -521,7 +521,7 @@ export class AuroMenuOption extends AuroElement {
     });
 
     return html`
-      <div class="${classes}">
+      <div class="${classes}" aria-disabled="${this.disabled ? 'true' : 'false'}">
         ${this.selected && !this.noCheckmark
         ? this.generateIconHtml(checkmarkIcon.svg)
         : undefined}

--- a/components/select/docs/partials/keyEvents.md
+++ b/components/select/docs/partials/keyEvents.md
@@ -136,7 +136,7 @@
       <td>
         The current <code>focused</code> option is selected.
         <div class="note">
-          <strong>Note:</strong> the page will also navigate to the next focusable element in the tabindex order.
+          <strong>Note:</strong> the page will also navigate to the next focusable element in the tabindex sequence.
         </div>
       </td>
     </tr>
@@ -145,9 +145,9 @@
       <td>Expanded</td>
       <td>Trigger element</td>
       <td>
-        Advances the <code>focused</code> option to the first enabled option in the list.
+        The current <code>focused</code> option is selected.
         <div class="note">
-          <strong>Note:</strong> the page will <strong>NOT</strong> navigate to the previous focusable element in the tabindex order.
+          <strong>Note:</strong> the page will also navigate to the previous focusable element in the tabindex sequence.
         </div>
       </td>
     </tr>

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -572,7 +572,8 @@ export class AuroSelect extends AuroElement {
           this.menu.updateActiveOption(this.optionSelected);
         } else if (this.multiSelect && Array.isArray(this.optionSelected) && this.optionSelected.length > 0) {
           this.menu.updateActiveOption(this.optionSelected[0]);
-        } else {
+        } else if (!this.menu.optionActive) {
+          // If no activeOption has yet to be set, then make the first enabled option active by default
           const firstActive = this.menu.menuService.menuOptions.find((option) => !option.disabled);
           this.menu.updateActiveOption(firstActive);
         }

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -1276,6 +1276,7 @@ export class AuroSelect extends AuroElement {
           <slot name="bib.fullscreen.headline" @slotchange="${this.handleSlotChange}"></slot>
         </div>
         <${this.dropdownTag}
+          disableKeyboardHandling
           appearance="${this.onDark ? 'inverse' : this.appearance}"
           .a11yRole=${"combobox"}
           ?autoPlacement="${this.autoPlacement}"
@@ -1355,6 +1356,7 @@ export class AuroSelect extends AuroElement {
           <slot name="bib.fullscreen.headline" @slotchange="${this.handleSlotChange}"></slot>
         </div>
         <${this.dropdownTag}
+          disableKeyboardHandling
           appearance="${this.onDark ? 'inverse' : this.appearance}"
           .a11yRole=${"combobox"}
           ?autoPlacement="${this.autoPlacement}"
@@ -1440,6 +1442,7 @@ export class AuroSelect extends AuroElement {
           <slot name="bib.fullscreen.headline" @slotchange="${this.handleSlotChange}"></slot>
         </div>
         <${this.dropdownTag}
+          disableKeyboardHandling
           appearance="${this.onDark ? 'inverse' : this.appearance}"
           .a11yRole=${"combobox"}
           ?autoPlacement="${this.autoPlacement}"

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -566,6 +566,19 @@ export class AuroSelect extends AuroElement {
       if (this.dropdown.isPopoverVisible) {
         this.updateMenuShapeSize();
 
+        // If there's a selected option, highlight it (per W3C APG combobox-select-only pattern)
+        // No selection → first enabled option gets highlighted
+        if (this.optionSelected && !Array.isArray(this.optionSelected)) {
+          this.menu.updateActiveOption(this.optionSelected);
+        } else if (this.multiSelect && Array.isArray(this.optionSelected) && this.optionSelected.length > 0) {
+          this.menu.updateActiveOption(this.optionSelected[0]);
+        } else {
+          const firstActive = this.menu.menuService.menuOptions.find((option) => !option.disabled);
+          this.menu.updateActiveOption(firstActive);
+        }
+
+        // Scroll the selected option into view when dropdown opens
+        this.scrollSelectedOptionIntoView();
         if (this.dropdown.isBibFullscreen) {
           // Hide the trigger from assistive technology so VoiceOver cannot reach it
           // behind the fullscreen dialog
@@ -577,17 +590,6 @@ export class AuroSelect extends AuroElement {
           // multiple Lit update cycles before moving focus into the bib
           doubleRaf(() => {
             this.bibtemplate.focusCloseButton();
-
-            // If there's a selected option, highlight it (per W3C APG combobox-select-only pattern)
-            // No selection → no highlight
-            if (this.optionSelected && !Array.isArray(this.optionSelected)) {
-              this.menu.updateActiveOption(this.optionSelected);
-            } else if (this.multiSelect && Array.isArray(this.optionSelected) && this.optionSelected.length > 0) {
-              this.menu.updateActiveOption(this.optionSelected[0]);
-            }
-
-            // Scroll the selected option into view when dropdown opens
-            this.scrollSelectedOptionIntoView();
           });
         } else {
           // wait til the bib gets fully rendered

--- a/components/select/src/selectKeyboardStrategy.js
+++ b/components/select/src/selectKeyboardStrategy.js
@@ -18,27 +18,17 @@ export const selectKeyboardStrategy = {
   },
 
   Enter(component, evt, ctx) {
-    // select is not opened yet by Floating UI
-    if (ctx.isExpanded) {
-      return;
+    if (!ctx.isExpanded && ctx.isPopover) {
+      component.menu.makeSelection();
+    } else if (ctx.isModal && !evt.defaultPrevented) {
+      // for modal, isExpanded is always true
+      // defaultPrevented will be true if Floating UI has already handled the event to open the dropdown
+      component.menu.makeSelection();
     }
-    evt.preventDefault();
-    component.menu.makeSelection();
   },
 
   Tab(component, evt, ctx) {
     if (!ctx.isExpanded) {
-      return;
-    }
-
-    // Shift+Tab moves the highlight to the first non-disabled option
-    // without making a selection or closing the bib.
-    if (evt.shiftKey) {
-      evt.preventDefault();
-      const firstActive = component.menu.menuService.menuOptions.find((option) => option.isActive);
-      if (firstActive) {
-        component.menu.updateActiveOption(firstActive);
-      }
       return;
     }
 

--- a/components/select/src/selectKeyboardStrategy.js
+++ b/components/select/src/selectKeyboardStrategy.js
@@ -29,6 +29,8 @@ export const selectKeyboardStrategy = {
   },
 
   Enter(component, evt, ctx) {
+    evt.preventDefault();
+    evt.stopPropagation();
     if (!ctx.isExpanded) {
       component.dropdown.show();
       return;

--- a/components/select/src/selectKeyboardStrategy.js
+++ b/components/select/src/selectKeyboardStrategy.js
@@ -1,44 +1,46 @@
+/* eslint-disable new-cap */
 import { navigateArrow } from '@aurodesignsystem/utils';
 
 export const selectKeyboardStrategy = {
   ArrowUp(component, evt, ctx) {
-    // Navigate menu only if the bib is open, otherwise open the bib
     evt.preventDefault();
     if (evt.altKey || evt.metaKey) {
       // navigate to first enabled option
-    } else if (component.dropdown.isPopoverVisible) {
-      navigateArrow(component, 'up', {
-        ctx,
-        showFn: () => component.dropdown.show(),
-      });
-    } else {
-      component.dropdown.show();
+      selectKeyboardStrategy.Home(component, evt, ctx);
+      return;
     }
+    navigateArrow(component, 'up', {
+      ctx,
+      showFn: () => component.dropdown.show(),
+    });
   },
 
   ArrowDown(component, evt, ctx) {
-    // Navigate menu only if the bib is open, otherwise open the bib
     evt.preventDefault();
     if (evt.altKey || evt.metaKey) {
       // navigate to last enabled option
-    } else if (component.dropdown.isPopoverVisible) {
-      navigateArrow(component, 'down', {
-        ctx,
-        showFn: () => component.dropdown.show(),
-      });
-    } else {
-      component.dropdown.show();
+      selectKeyboardStrategy.End(component, evt, ctx);
+      return;
     }
+    navigateArrow(component, 'down', {
+      ctx,
+      showFn: () => component.dropdown.show(),
+    });
   },
 
   Enter(component, evt, ctx) {
-    if (!ctx.isExpanded && ctx.isPopover) {
-      component.menu.makeSelection();
-    } else if (ctx.isModal && !evt.defaultPrevented) {
-      // for modal, isExpanded is always true
-      // defaultPrevented will be true if Floating UI has already handled the event to open the dropdown
-      component.menu.makeSelection();
+    if (!ctx.isExpanded) {
+      component.dropdown.show();
+      return;
     }
+    component.menu.makeSelection();
+  },
+
+  Escape(component, evt, ctx) {
+    if (!ctx.isExpanded) {
+      return;
+    }
+    component.dropdown.hide();
   },
 
   Tab(component, evt, ctx) {
@@ -53,7 +55,10 @@ export const selectKeyboardStrategy = {
     }
     component.dropdown.hide();
   },
-  Home(component, evt) {
+  Home(component, evt, ctx) {
+    if (!ctx.isExpanded) {
+      return;
+    }
     evt.preventDefault();
     evt.stopPropagation();
     const firstOption = component.menu.menuService.menuOptions.find((option) => !option.disabled);
@@ -62,7 +67,10 @@ export const selectKeyboardStrategy = {
     }
   },
 
-  End(component, evt) {
+  End(component, evt, ctx) {
+    if (!ctx.isExpanded) {
+      return;
+    }
     evt.preventDefault();
     evt.stopPropagation();
     const lastOption = [...component.menu.menuService.menuOptions].reverse().find((option) => !option.disabled);
@@ -71,7 +79,16 @@ export const selectKeyboardStrategy = {
     }
   },
 
-  default(component, evt) {
+  default(component, evt, ctx) {
     component.updateActiveOptionBasedOnKey(evt.key);
+    if (evt.key === ' ') {
+      evt.preventDefault();
+      evt.stopPropagation();
+      if (ctx.isExpanded) {
+        component.dropdown.hide();
+        return;
+      }
+      component.dropdown.show();
+    }
   },
 };

--- a/components/select/src/selectKeyboardStrategy.js
+++ b/components/select/src/selectKeyboardStrategy.js
@@ -2,19 +2,33 @@ import { navigateArrow } from '@aurodesignsystem/utils';
 
 export const selectKeyboardStrategy = {
   ArrowUp(component, evt, ctx) {
+    // Navigate menu only if the bib is open, otherwise open the bib
     evt.preventDefault();
-    navigateArrow(component, 'up', {
-      ctx,
-      showFn: () => component.dropdown.show(),
-    });
+    if (evt.altKey || evt.metaKey) {
+      // navigate to first enabled option
+    } else if (component.dropdown.isPopoverVisible) {
+      navigateArrow(component, 'up', {
+        ctx,
+        showFn: () => component.dropdown.show(),
+      });
+    } else {
+      component.dropdown.show();
+    }
   },
 
   ArrowDown(component, evt, ctx) {
+    // Navigate menu only if the bib is open, otherwise open the bib
     evt.preventDefault();
-    navigateArrow(component, 'down', {
-      ctx,
-      showFn: () => component.dropdown.show(),
-    });
+    if (evt.altKey || evt.metaKey) {
+      // navigate to last enabled option
+    } else if (component.dropdown.isPopoverVisible) {
+      navigateArrow(component, 'down', {
+        ctx,
+        showFn: () => component.dropdown.show(),
+      });
+    } else {
+      component.dropdown.show();
+    }
   },
 
   Enter(component, evt, ctx) {

--- a/components/select/src/selectKeyboardStrategy.js
+++ b/components/select/src/selectKeyboardStrategy.js
@@ -17,7 +17,11 @@ export const selectKeyboardStrategy = {
     });
   },
 
-  Enter(component, evt) {
+  Enter(component, evt, ctx) {
+    // select is not opened yet by Floating UI
+    if (ctx.isExpanded) {
+      return;
+    }
     evt.preventDefault();
     component.menu.makeSelection();
   },
@@ -44,6 +48,23 @@ export const selectKeyboardStrategy = {
       component.menu.makeSelection();
     }
     component.dropdown.hide();
+  },
+  Home(component, evt) {
+    evt.preventDefault();
+    evt.stopPropagation();
+    const firstOption = component.menu.menuService.menuOptions.find((option) => !option.disabled);
+    if (firstOption) {
+      component.menu.updateActiveOption(firstOption);
+    }
+  },
+
+  End(component, evt) {
+    evt.preventDefault();
+    evt.stopPropagation();
+    const lastOption = [...component.menu.menuService.menuOptions].reverse().find((option) => !option.disabled);
+    if (lastOption) {
+      component.menu.updateActiveOption(lastOption);
+    }
   },
 
   default(component, evt) {

--- a/components/select/stories/component.stories.ts
+++ b/components/select/stories/component.stories.ts
@@ -76,20 +76,20 @@ export const SelectKeyboardNavAndEnter: Story = {
     await userEvent.click(trigger);
     await expect(el.isPopoverVisible).toBe(true);
 
-    // ArrowDown twice → "Price" is active
+    // ArrowDown twice → "Duration" is active
     el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
     el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
 
     // Wait for menu to reflect active state
     await new Promise((r) => setTimeout(r, 50));
-    const priceOption = el.querySelector('auro-menuoption[value="price"]');
-    await expect(priceOption.classList.contains('active')).toBe(true);
+    const durationOption = el.querySelector('auro-menuoption[value="duration"]');
+    await expect(durationOption.classList.contains('active')).toBe(true);
 
     // Enter confirms selection
     el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
     await new Promise((r) => setTimeout(r, 50));
 
-    await expect(el.value).toBe('price');
+    await expect(el.value).toBe('duration');
     await expect(el.isPopoverVisible).toBe(false);
   },
 };
@@ -123,7 +123,7 @@ export const SelectTabSelectsOption: Story = {
     el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
     await new Promise((r) => setTimeout(r, 50));
 
-    await expect(el.value).toBe('stops');
+    await expect(el.value).toBe('price');
     await expect(el.isPopoverVisible).toBe(false);
   },
 };
@@ -153,7 +153,7 @@ export const SelectEscapeClosesWithoutSelect: Story = {
     await new Promise((r) => setTimeout(r, 50));
 
     // Escape via document-level dispatch (matches how auroFloatingUI listens)
-    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
     await new Promise((r) => setTimeout(r, 50));
 
     await expect(el.isPopoverVisible).toBe(false);
@@ -216,7 +216,7 @@ export const SelectAriaComboboxAttributes: Story = {
     await expect(trigger.getAttribute('aria-expanded')).toBe('true');
 
     // Close via Escape
-    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
     await new Promise((r) => setTimeout(r, 50));
     await expect(trigger.getAttribute('aria-expanded')).toBe('false');
   },
@@ -256,8 +256,8 @@ export const SelectShiftTabMovesToFirstOption: Story = {
     await new Promise((r) => setTimeout(r, 50));
 
     await expect(firstOption.classList.contains('active')).toBe(true);
-    await expect(el.isPopoverVisible).toBe(true);
-    await expect(el.value).toBeUndefined();
+    await expect(el.isPopoverVisible).toBe(false);
+    await expect(el.value).toBe('stops');
   },
 };
 

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -32,6 +32,8 @@ async function defaultFixture() {
     <auro-menu>
       <auro-menuoption value="Apples" id="option-0">Apples</auro-menuoption>
       <auro-menuoption value="Oranges" id="option-1">Oranges</auro-menuoption>
+      <auro-menuoption value="Bananas" id="option-2">Bananas</auro-menuoption>
+      <auro-menuoption value="Grapes" id="option-3">Grapes</auro-menuoption>
     </auro-menu>
   </auro-select>
   `);
@@ -181,36 +183,6 @@ async function requiredFixture() {
     <auro-menu>
       <auro-menuoption value="Apples" id="option-0">Apples</auro-menuoption>
       <auro-menuoption value="Oranges" id="option-1">Oranges</auro-menuoption>
-    </auro-menu>
-  </auro-select>
-  `);
-}
-
-// WHAT IS THIS ONE USED FOR?
-async function shiftTabFixture() {
-  return await fixture(html`
-  <auro-select>
-    <span slot="bib.fullscreen.headline">Bib Headline</span>
-    <span slot="label">Name</span>
-    <auro-menu>
-      <auro-menuoption value="Stops" id="sh-option-0">Stops</auro-menuoption>
-      <auro-menuoption value="Price" id="sh-option-1">Price</auro-menuoption>
-      <auro-menuoption value="Duration" id="sh-option-2">Duration</auro-menuoption>
-    </auro-menu>
-  </auro-select>
-  `);
-}
-
-// THIS IS PROBABLY NOT NECESSARY ANY MORE?
-async function shiftTabDisabledFirstFixture() {
-  return await fixture(html`
-  <auro-select>
-    <span slot="bib.fullscreen.headline">Bib Headline</span>
-    <span slot="label">Name</span>
-    <auro-menu>
-      <auro-menuoption value="Stops" id="sh-dis-option-0" disabled>Stops</auro-menuoption>
-      <auro-menuoption value="Price" id="sh-dis-option-1">Price</auro-menuoption>
-      <auro-menuoption value="Duration" id="sh-dis-option-2">Duration</auro-menuoption>
     </auro-menu>
   </auro-select>
   `);
@@ -437,23 +409,23 @@ function runTest(mobileView) {
       });
     }
 
-    // // ─── §2.1.2  Enter key selects active option and closes bib (P0) ────────
-    // it('Enter key selects the active option and closes the bib', async () => {
-    //   const el = await defaultFixture();
-    //   const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
-    //   const trigger = dropdown.querySelector('[slot="trigger"]');
+    // ─── §2.1.2  Enter key selects active option and closes bib (P0) ────────
+    it('Enter key selects the active option and closes the bib', async () => {
+      const el = await defaultFixture();
+      const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+      const trigger = dropdown.querySelector('[slot="trigger"]');
 
-    //   trigger.click();
-    //   await expect(dropdown.isPopoverVisible).to.be.true;
+      trigger.click();
+      await expect(dropdown.isPopoverVisible).to.be.true;
 
-    //   el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
-    //   await elementUpdated(el);
-    //   el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
-    //   await elementUpdated(el);
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      await elementUpdated(el);
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      await elementUpdated(el);
 
-    //   await expect(el.value).to.equal('Oranges');
-    //   await expect(dropdown.isPopoverVisible).to.be.false;
-    // });
+      await expect(el.value).to.equal('Oranges');
+      await expect(dropdown.isPopoverVisible).to.be.false;
+    });
 
     // ─── §2.1.3  Tab selects active option and closes bib (P0) ──────────────
     it('Tab selects the active option and closes the bib', async () => {
@@ -497,7 +469,7 @@ function runTest(mobileView) {
     });
 
     it('Shift+Tab with bib closed does nothing', async () => {
-      const el = await shiftTabFixture();
+      const el = await defaultFixture();
       const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
 
       await expect(dropdown.isPopoverVisible).to.be.false;
@@ -521,7 +493,7 @@ function runTest(mobileView) {
       el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
       await elementUpdated(el);
 
-      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
       await elementUpdated(el);
 
       await expect(dropdown.isPopoverVisible).to.be.false;
@@ -1116,38 +1088,24 @@ describe('selectKeyboardStrategy — Tab multiselect', () => {
 
 describe('auro-select keyboard behavior — Home key', () => {
   it('moves to the first enabled option when Home is pressed while expanded', async () => {
-    // just use default fixture
-    const el = await fixture(html`
-      <auro-select>
-        <span slot="bib.fullscreen.headline">Bib Headline</span>
-        <span slot="label">Name</span>
-        <auro-menu>
-          <auro-menuoption value="Stops">Stops</auro-menuoption>
-          <auro-menuoption value="Price">Price</auro-menuoption>
-          <auro-menuoption value="Duration">Duration</auro-menuoption>
-        </auro-menu>
-      </auro-select>
-    `);
+    const el = await defaultFixture();
 
-    await elementUpdated(el);
     el.showBib();
     await elementUpdated(el);
 
     // Navigate to the last option
-    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
-    await elementUpdated(el);
-    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' }));
     await elementUpdated(el);
 
     const menu = el.querySelector('auro-menu');
-    const lastOption = menu.querySelector('auro-menuoption[value="Duration"]');
+    const lastOption = menu.querySelector('auro-menuoption[value="Grapes"]');
     await expect(el.optionActive === lastOption).to.be.true;
 
     // Press Home to go to first option
     el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Home' }));
     await elementUpdated(el);
 
-    const firstOption = menu.querySelector('auro-menuoption[value="Stops"]');
+    const firstOption = menu.querySelector('auro-menuoption[value="Apples"]');
     await expect(el.optionActive === firstOption).to.be.true;
 
     // wrap to last option if Home is pressed again
@@ -1158,18 +1116,9 @@ describe('auro-select keyboard behavior — Home key', () => {
   });
 
   it('skips disabled options and goes to first enabled option when Home is pressed', async () => {
-    // just use default fixture
-    const el = await fixture(html`
-      <auro-select>
-        <span slot="bib.fullscreen.headline">Bib Headline</span>
-        <span slot="label">Name</span>
-        <auro-menu>
-          <auro-menuoption value="Stops" disabled>Stops</auro-menuoption>
-          <auro-menuoption value="Price">Price</auro-menuoption>
-          <auro-menuoption value="Duration">Duration</auro-menuoption>
-        </auro-menu>
-      </auro-select>
-    `);
+    const el = await defaultFixture();
+    const menu = el.querySelector('auro-menu');
+    menu.querySelector('auro-menuoption').setAttribute('disabled', '');
 
     await elementUpdated(el);
     el.showBib();
@@ -1183,14 +1132,13 @@ describe('auro-select keyboard behavior — Home key', () => {
     el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
     await elementUpdated(el);
 
-    await expect(el.optionActive.value).to.equal('Duration');
+    await expect(el.optionActive.value).to.equal('Oranges');
 
     // Press Home, should skip the disabled first option and go to "Price"
     el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Home' }));
     await elementUpdated(el);
 
-    const menu = el.querySelector('auro-menu');
-    const firstEnabledOption = menu.querySelector('auro-menuoption[value="Price"]');
+    const firstEnabledOption = menu.querySelector('auro-menuoption[value="Oranges"]');
     await expect(el.optionActive).to.equal(firstEnabledOption);
   });
 
@@ -1218,17 +1166,7 @@ describe('auro-select keyboard behavior — Home key', () => {
   });
 
   it('does nothing when Home is pressed while collapsed', async () => {
-    // just use default fixture
-    const el = await fixture(html`
-      <auro-select>
-        <span slot="bib.fullscreen.headline">Bib Headline</span>
-        <span slot="label">Name</span>
-        <auro-menu>
-          <auro-menuoption value="Stops">Stops</auro-menuoption>
-          <auro-menuoption value="Price">Price</auro-menuoption>
-        </auro-menu>
-      </auro-select>
-    `);
+    const el = await defaultFixture();
 
     await elementUpdated(el);
 
@@ -1246,18 +1184,7 @@ describe('auro-select keyboard behavior — Home key', () => {
 
 describe('auro-select keyboard behavior — End key', () => {
   it('moves to the last enabled option when End is pressed while expanded', async () => {
-    // just use default fixture
-    const el = await fixture(html`
-      <auro-select>
-        <span slot="bib.fullscreen.headline">Bib Headline</span>
-        <span slot="label">Name</span>
-        <auro-menu>
-          <auro-menuoption value="Stops">Stops</auro-menuoption>
-          <auro-menuoption value="Price">Price</auro-menuoption>
-          <auro-menuoption value="Duration">Duration</auro-menuoption>
-        </auro-menu>
-      </auro-select>
-    `);
+    const el = await defaultFixture();
 
     await elementUpdated(el);
     el.showBib();
@@ -1268,7 +1195,7 @@ describe('auro-select keyboard behavior — End key', () => {
     await elementUpdated(el);
 
     const menu = el.querySelector('auro-menu');
-    const lastOption = menu.querySelector('auro-menuoption[value="Duration"]');
+    const lastOption = menu.querySelector('auro-menuoption[value="Grapes"]');
     await expect(el.optionActive).to.equal(lastOption);
   });
 
@@ -1332,16 +1259,7 @@ describe('auro-select keyboard behavior — End key', () => {
   });
 
   it('does nothing when End is pressed while collapsed', async () => {
-    const el = await fixture(html`
-      <auro-select>
-        <span slot="bib.fullscreen.headline">Bib Headline</span>
-        <span slot="label">Name</span>
-        <auro-menu>
-          <auro-menuoption value="Stops">Stops</auro-menuoption>
-          <auro-menuoption value="Price">Price</auro-menuoption>
-        </auro-menu>
-      </auro-select>
-    `);
+    const el = await defaultFixture();
 
     await elementUpdated(el);
 
@@ -1357,76 +1275,177 @@ describe('auro-select keyboard behavior — End key', () => {
   });
 });
 
+describe('auro-select keyboard behavior — Command key', () => {
+  it('advances to the last enabled option when Command is pressed while expanded', async () => {
+    const el = await defaultFixture();
+
+    await elementUpdated(el);
+    el.showBib();
+    await elementUpdated(el);
+
+    const menu = el.querySelector('auro-menu');
+    const lastOption = menu.querySelector('auro-menuoption[value="Grapes"]');
+
+    // Press Command to jump to last option
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', metaKey: true }));
+    await elementUpdated(el);
+
+    await expect(el.optionActive === lastOption).to.equal(true);
+  });
+
+  it('skips disabled options and goes to last enabled option when Command is pressed', async () => {
+    const el = await fixture(html`
+      <auro-select>
+        <span slot="bib.fullscreen.headline">Bib Headline</span>
+        <span slot="label">Name</span>
+        <auro-menu>
+          <auro-menuoption value="Stops">Stops</auro-menuoption>
+          <auro-menuoption value="Price">Price</auro-menuoption>
+          <auro-menuoption value="Duration" disabled>Duration</auro-menuoption>
+        </auro-menu>
+      </auro-select>
+    `);
+
+    await elementUpdated(el);
+    el.showBib();
+    await elementUpdated(el);
+
+    const menu = el.querySelector('auro-menu');
+    const lastEnabledOption = menu.querySelector('auro-menuoption[value="Price"]');
+
+    // Press Command, should skip the disabled last option and go to "Price"
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', metaKey: true }));
+    await elementUpdated(el);
+
+    await expect(el.optionActive === lastEnabledOption).to.equal(true);
+  });
+});
+
+describe('auro-select keyboard behavior — Option key', () => {
+  it('advances to the last enabled option when Option is pressed while expanded', async () => {
+    const el = await defaultFixture();
+
+    await elementUpdated(el);
+    el.showBib();
+    await elementUpdated(el);
+
+    const menu = el.querySelector('auro-menu');
+    const lastOption = menu.querySelector('auro-menuoption[value="Grapes"]');
+
+    // Press Option (Alt) to jump to last option
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', altKey: true }));
+    await elementUpdated(el);
+
+    await expect(el.optionActive === lastOption).to.equal(true);
+  });
+
+  it('skips disabled options and goes to last enabled option when Option is pressed', async () => {
+    const el = await fixture(html`
+      <auro-select>
+        <span slot="bib.fullscreen.headline">Bib Headline</span>
+        <span slot="label">Name</span>
+        <auro-menu>
+          <auro-menuoption value="Stops">Stops</auro-menuoption>
+          <auro-menuoption value="Price">Price</auro-menuoption>
+          <auro-menuoption value="Duration" disabled>Duration</auro-menuoption>
+        </auro-menu>
+      </auro-select>
+    `);
+
+    await elementUpdated(el);
+    el.showBib();
+    await elementUpdated(el);
+
+    const menu = el.querySelector('auro-menu');
+    const lastEnabledOption = menu.querySelector('auro-menuoption[value="Price"]');
+
+    // Press Option (Alt), should skip the disabled last option and go to "Price"
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', altKey: true }));
+    await elementUpdated(el);
+
+    await expect(el.optionActive === lastEnabledOption).to.equal(true);
+  });
+});
+
 describe('auro-select keyboard behavior — Space key', () => {
-//   it('expands the bib when Space is pressed while collapsed and enabled', async () => {
-//     const el = await fixture(html`
-//       <auro-select>
-//         <span slot="bib.fullscreen.headline">Bib Headline</span>
-//         <span slot="label">Name</span>
-//         <auro-menu>
-//           <auro-menuoption value="Stops">Stops</auro-menuoption>
-//           <auro-menuoption value="Price">Price</auro-menuoption>
-//         </auro-menu>
-//       </auro-select>
-//     `);
+  it('expands the bib when Space is pressed while collapsed and enabled', async () => {
+    const el = await defaultFixture();
 
-//     await elementUpdated(el);
+    await elementUpdated(el);
 
-//     const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
-//     await expect(dropdown.isPopoverVisible).to.be.false;
+    const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+    await expect(dropdown.isPopoverVisible).to.be.false;
 
-//     el.dispatchEvent(new KeyboardEvent('keydown', { key: ' ' }));
-//     await elementUpdated(el);
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: ' ' }));
+    await elementUpdated(el);
 
-//     await expect(dropdown.isPopoverVisible).to.be.true;
-//   });
+    await expect(dropdown.isPopoverVisible).to.be.true;
+  });
 
-  // it('collapses the bib when Space is pressed while expanded and enabled', async () => {
-  //   const el = await fixture(html`
-  //     <auro-select>
-  //       <span slot="bib.fullscreen.headline">Bib Headline</span>
-  //       <span slot="label">Name</span>
-  //       <auro-menu>
-  //         <auro-menuoption value="Stops">Stops</auro-menuoption>
-  //         <auro-menuoption value="Price">Price</auro-menuoption>
-  //       </auro-menu>
-  //     </auro-select>
-  //   `);
+  it('collapses the bib when Space is pressed while expanded and enabled', async () => {
+    const el = await defaultFixture();
 
-  //   await elementUpdated(el);
-  //   el.showBib();
-  //   await elementUpdated(el);
+    await elementUpdated(el);
+    el.showBib();
+    await elementUpdated(el);
 
-  //   const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
-  //   await expect(dropdown.isPopoverVisible).to.be.true;
+    const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+    await expect(dropdown.isPopoverVisible).to.be.true;
 
-  //   el.dispatchEvent(new KeyboardEvent('keydown', { key: ' ' }));
-  //   await elementUpdated(el);
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: ' ' }));
+    await elementUpdated(el);
 
-  //   await expect(dropdown.isPopoverVisible).to.be.false;
-  //   await expect(el.value).to.be.undefined;
-  // });
+    await expect(dropdown.isPopoverVisible).to.be.false;
+    await expect(el.value).to.be.undefined;
+  });
 
-  // it('does nothing when Space is pressed on a disabled component', async () => {
-  //   const el = await fixture(html`
-  //     <auro-select disabled>
-  //       <span slot="bib.fullscreen.headline">Bib Headline</span>
-  //       <span slot="label">Name</span>
-  //       <auro-menu>
-  //         <auro-menuoption value="Stops">Stops</auro-menuoption>
-  //         <auro-menuoption value="Price">Price</auro-menuoption>
-  //       </auro-menu>
-  //     </auro-select>
-  //   `);
+  it('does nothing when Space is pressed on a disabled component', async () => {
+    const el = await defaultFixture();
+    el.disabled = true;
+    el.ariaDisabled = 'true';
 
-  //   await elementUpdated(el);
+    await elementUpdated(el);
 
-  //   const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
-  //   await expect(dropdown.isPopoverVisible).to.be.false;
+    const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+    await expect(dropdown.isPopoverVisible).to.be.false;
 
-  //   el.dispatchEvent(new KeyboardEvent('keydown', { key: ' ' }));
-  //   await elementUpdated(el);
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: ' ' }));
+    await elementUpdated(el);
 
-  //   await expect(dropdown.isPopoverVisible).to.be.false;
-  // });
+    await expect(dropdown.isPopoverVisible).to.be.false;
+  });
+});
+
+describe('auro-select keyboard behavior — ArrowDown when collapsed', () => {
+  it('opens the bib when ArrowDown is pressed while collapsed', async () => {
+    const el = await defaultFixture();
+
+    await elementUpdated(el);
+
+    const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+    await expect(dropdown.isPopoverVisible).to.be.false;
+
+    // Press ArrowDown while collapsed
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    await elementUpdated(el);
+
+    // Dropdown should now be open
+    await expect(dropdown.isPopoverVisible).to.be.true;
+  });
+});
+
+describe('auro-select keyboard behavior — ArrowUp when collapsed', () => {
+  it('opens the bib when ArrowUp is pressed while collapsed', async () => {
+    const el = await defaultFixture();
+
+    const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+    await expect(dropdown.isPopoverVisible).to.be.false;
+
+    // Press ArrowUp while collapsed
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' }));
+    await elementUpdated(el);
+
+    // Dropdown should now be open
+    await expect(dropdown.isPopoverVisible).to.be.true;
+  });
 });

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines, jsdoc/require-jsdoc, no-return-await, no-undef */
 import { useAccessibleIt } from "@aurodesignsystem/auro-library/scripts/test-plugin/iterateWithA11Check.mjs";
 
-import { fixture, html, expect, elementUpdated, waitUntil } from '@open-wc/testing';
+import { fixture, html, expect, elementUpdated } from '@open-wc/testing';
 import { setViewport } from '@web/test-runner-commands';
 import { selectKeyboardStrategy } from '../src/selectKeyboardStrategy.js';
 import '@aurodesignsystem/auro-dropdown';
@@ -186,6 +186,7 @@ async function requiredFixture() {
   `);
 }
 
+// WHAT IS THIS ONE USED FOR?
 async function shiftTabFixture() {
   return await fixture(html`
   <auro-select>
@@ -200,6 +201,7 @@ async function shiftTabFixture() {
   `);
 }
 
+// THIS IS PROBABLY NOT NECESSARY ANY MORE?
 async function shiftTabDisabledFirstFixture() {
   return await fixture(html`
   <auro-select>
@@ -435,23 +437,23 @@ function runTest(mobileView) {
       });
     }
 
-    // ─── §2.1.2  Enter key selects active option and closes bib (P0) ────────
-    it('Enter key selects the active option and closes the bib', async () => {
-      const el = await defaultFixture();
-      const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
-      const trigger = dropdown.querySelector('[slot="trigger"]');
+    // // ─── §2.1.2  Enter key selects active option and closes bib (P0) ────────
+    // it('Enter key selects the active option and closes the bib', async () => {
+    //   const el = await defaultFixture();
+    //   const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+    //   const trigger = dropdown.querySelector('[slot="trigger"]');
 
-      trigger.click();
-      await expect(dropdown.isPopoverVisible).to.be.true;
+    //   trigger.click();
+    //   await expect(dropdown.isPopoverVisible).to.be.true;
 
-      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
-      await elementUpdated(el);
-      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
-      await elementUpdated(el);
+    //   el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    //   await elementUpdated(el);
+    //   el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    //   await elementUpdated(el);
 
-      await expect(el.value).to.equal('Oranges');
-      await expect(dropdown.isPopoverVisible).to.be.false;
-    });
+    //   await expect(el.value).to.equal('Oranges');
+    //   await expect(dropdown.isPopoverVisible).to.be.false;
+    // });
 
     // ─── §2.1.3  Tab selects active option and closes bib (P0) ──────────────
     it('Tab selects the active option and closes the bib', async () => {
@@ -1114,6 +1116,7 @@ describe('selectKeyboardStrategy — Tab multiselect', () => {
 
 describe('auro-select keyboard behavior — Home key', () => {
   it('moves to the first enabled option when Home is pressed while expanded', async () => {
+    // just use default fixture
     const el = await fixture(html`
       <auro-select>
         <span slot="bib.fullscreen.headline">Bib Headline</span>
@@ -1155,6 +1158,7 @@ describe('auro-select keyboard behavior — Home key', () => {
   });
 
   it('skips disabled options and goes to first enabled option when Home is pressed', async () => {
+    // just use default fixture
     const el = await fixture(html`
       <auro-select>
         <span slot="bib.fullscreen.headline">Bib Headline</span>
@@ -1214,6 +1218,7 @@ describe('auro-select keyboard behavior — Home key', () => {
   });
 
   it('does nothing when Home is pressed while collapsed', async () => {
+    // just use default fixture
     const el = await fixture(html`
       <auro-select>
         <span slot="bib.fullscreen.headline">Bib Headline</span>
@@ -1241,6 +1246,7 @@ describe('auro-select keyboard behavior — Home key', () => {
 
 describe('auro-select keyboard behavior — End key', () => {
   it('moves to the last enabled option when End is pressed while expanded', async () => {
+    // just use default fixture
     const el = await fixture(html`
       <auro-select>
         <span slot="bib.fullscreen.headline">Bib Headline</span>
@@ -1349,4 +1355,78 @@ describe('auro-select keyboard behavior — End key', () => {
     // Dropdown should still be closed
     await expect(dropdown.isPopoverVisible).to.be.false;
   });
+});
+
+describe('auro-select keyboard behavior — Space key', () => {
+//   it('expands the bib when Space is pressed while collapsed and enabled', async () => {
+//     const el = await fixture(html`
+//       <auro-select>
+//         <span slot="bib.fullscreen.headline">Bib Headline</span>
+//         <span slot="label">Name</span>
+//         <auro-menu>
+//           <auro-menuoption value="Stops">Stops</auro-menuoption>
+//           <auro-menuoption value="Price">Price</auro-menuoption>
+//         </auro-menu>
+//       </auro-select>
+//     `);
+
+//     await elementUpdated(el);
+
+//     const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+//     await expect(dropdown.isPopoverVisible).to.be.false;
+
+//     el.dispatchEvent(new KeyboardEvent('keydown', { key: ' ' }));
+//     await elementUpdated(el);
+
+//     await expect(dropdown.isPopoverVisible).to.be.true;
+//   });
+
+  // it('collapses the bib when Space is pressed while expanded and enabled', async () => {
+  //   const el = await fixture(html`
+  //     <auro-select>
+  //       <span slot="bib.fullscreen.headline">Bib Headline</span>
+  //       <span slot="label">Name</span>
+  //       <auro-menu>
+  //         <auro-menuoption value="Stops">Stops</auro-menuoption>
+  //         <auro-menuoption value="Price">Price</auro-menuoption>
+  //       </auro-menu>
+  //     </auro-select>
+  //   `);
+
+  //   await elementUpdated(el);
+  //   el.showBib();
+  //   await elementUpdated(el);
+
+  //   const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+  //   await expect(dropdown.isPopoverVisible).to.be.true;
+
+  //   el.dispatchEvent(new KeyboardEvent('keydown', { key: ' ' }));
+  //   await elementUpdated(el);
+
+  //   await expect(dropdown.isPopoverVisible).to.be.false;
+  //   await expect(el.value).to.be.undefined;
+  // });
+
+  // it('does nothing when Space is pressed on a disabled component', async () => {
+  //   const el = await fixture(html`
+  //     <auro-select disabled>
+  //       <span slot="bib.fullscreen.headline">Bib Headline</span>
+  //       <span slot="label">Name</span>
+  //       <auro-menu>
+  //         <auro-menuoption value="Stops">Stops</auro-menuoption>
+  //         <auro-menuoption value="Price">Price</auro-menuoption>
+  //       </auro-menu>
+  //     </auro-select>
+  //   `);
+
+  //   await elementUpdated(el);
+
+  //   const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+  //   await expect(dropdown.isPopoverVisible).to.be.false;
+
+  //   el.dispatchEvent(new KeyboardEvent('keydown', { key: ' ' }));
+  //   await elementUpdated(el);
+
+  //   await expect(dropdown.isPopoverVisible).to.be.false;
+  // });
 });

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -1402,7 +1402,6 @@ describe('auro-select keyboard behavior — Space key', () => {
   it('does nothing when Space is pressed on a disabled component', async () => {
     const el = await defaultFixture();
     el.disabled = true;
-    el.ariaDisabled = 'true';
 
     await elementUpdated(el);
 

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines, jsdoc/require-jsdoc, no-return-await, no-undef */
 import { useAccessibleIt } from "@aurodesignsystem/auro-library/scripts/test-plugin/iterateWithA11Check.mjs";
 
-import { fixture, html, expect, elementUpdated } from '@open-wc/testing';
+import { fixture, html, expect, elementUpdated, waitUntil } from '@open-wc/testing';
 import { setViewport } from '@web/test-runner-commands';
 import { selectKeyboardStrategy } from '../src/selectKeyboardStrategy.js';
 import '@aurodesignsystem/auro-dropdown';
@@ -435,6 +435,28 @@ function runTest(mobileView) {
       });
     }
 
+    // ─── §2.1.2  Enter key selects active option and closes bib (P0) ────────
+    it('Enter key selects the active option and closes the bib', async () => {
+      const el = await defaultFixture();
+      const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+      const trigger = dropdown.querySelector('[slot="trigger"]');
+
+      trigger.click();
+      await expect(dropdown.isPopoverVisible).to.be.true;
+
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      await elementUpdated(el);
+
+      if (mobileView) {
+        el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      } else {
+        trigger.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      }
+      await elementUpdated(el);
+
+      await waitUntil(() => dropdown.isPopoverVisible === false, 'Dropdown did not close after Enter key');
+      await expect(el.value).to.equal('Oranges');
+    });
 
     // ─── §2.1.3  Tab selects active option and closes bib (P0) ──────────────
     it('Tab selects the active option and closes the bib', async () => {
@@ -452,26 +474,8 @@ function runTest(mobileView) {
       el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
       await elementUpdated(el);
 
-      await expect(el.value).to.equal('Apples');
       await expect(dropdown.isPopoverVisible).to.be.false;
-    });
-
-    // ─── §2.1.4  Tab with no highlighted option closes without selecting (P1) ─
-    it('Tab with no highlighted option closes bib without selecting', async () => {
-      const el = await defaultFixture();
-      const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
-      const trigger = dropdown.querySelector('[slot="trigger"]');
-
-      trigger.click();
-      await elementUpdated(el);
-      await expect(dropdown.isPopoverVisible).to.be.true;
-
-      // Do NOT navigate to any option before Tab
-      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
-      await elementUpdated(el);
-
-      await expect(dropdown.isPopoverVisible).to.be.false;
-      await expect(el.value).to.be.undefined;
+      await expect(el.value).to.equal('Oranges');
     });
 
     // ─── §2.1.X  Shift+Tab moves active option to first non-disabled option (P0) ─
@@ -490,15 +494,13 @@ function runTest(mobileView) {
       await elementUpdated(el);
       el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
       await elementUpdated(el);
-      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
-      await elementUpdated(el);
-      await expect(el.optionActive).to.equal(options[2]);
+      await expect(el.optionActive === options[2]).to.be.true;
 
       // Shift+Tab should move to the first option without selecting or closing
       el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true }));
       await elementUpdated(el);
 
-      await expect(el.optionActive).to.equal(options[0]);
+      await expect(el.optionActive === options[0]).to.be.true;
       await expect(dropdown.isPopoverVisible).to.be.true;
       await expect(el.value).to.be.undefined;
     });
@@ -609,11 +611,32 @@ function runTest(mobileView) {
       el.showBib();
       await elementUpdated(el);
 
-      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
-      await elementUpdated(el);
-
-      await expect(trigger.ariaActiveDescendantElement).to.equal(firstOption);
+      await expect(trigger.ariaActiveDescendantElement === firstOption).to.be.true;
     });
+
+    if (mobileView) {
+      // ─── §2.2.3  Option selection in fullscreen mode (P0) ───────────────────
+      it('selecting an option in fullscreen mode sets value and closes dialog', async () => {
+        const el = await defaultFixture();
+        const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+        const trigger = dropdown.querySelector('[slot="trigger"]');
+
+        trigger.click();
+        await expect(dropdown.isPopoverVisible).to.be.true;
+
+        // Wait for fullscreen dialog to settle (double-rAF used by focus migration)
+        await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+
+        el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+        await elementUpdated(el);
+
+        el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+        await elementUpdated(el);
+
+        await expect(el.value).to.equal('Oranges');
+        await expect(dropdown.isPopoverVisible).to.be.false;
+        });
+    }
 
     it('Navigates the menu with arrow keys', async () => {
       const el = await defaultFixture();
@@ -622,9 +645,6 @@ function runTest(mobileView) {
 
       trigger.click();
       await expect(dropdown.isPopoverVisible).to.be.true;
-      el.dispatchEvent(new KeyboardEvent('keydown', {
-        'key': 'ArrowDown'
-      }));
 
       const menu = el.querySelector('auro-menu');
       const menuOptions = menu.querySelectorAll('auro-menuoption');
@@ -659,25 +679,23 @@ function runTest(mobileView) {
       await elementUpdated(el);
       await expect(dropdown.isPopoverVisible).to.be.true;
 
-      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
-      await elementUpdated(el);
-      await expect(el.optionActive).to.equal(rootOptions[0]);
+      await expect(el.optionActive === rootOptions[0]).to.be.true;
 
       el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
       await elementUpdated(el);
-      await expect(el.optionActive).to.equal(nestedOptions[0]);
+      await expect(el.optionActive === nestedOptions[0]).to.be.true;
 
       el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
       await elementUpdated(el);
-      await expect(el.optionActive).to.equal(nestedOptions[1]);
+      await expect(el.optionActive === nestedOptions[1]).to.be.true;
 
       el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
       await elementUpdated(el);
-      await expect(el.optionActive).to.equal(rootOptions[1]);
+      await expect(el.optionActive === rootOptions[1]).to.be.true;
 
       el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' }));
       await elementUpdated(el);
-      await expect(el.optionActive).to.equal(nestedOptions[1]);
+      await expect(el.optionActive === nestedOptions[1]).to.be.true;
     });
 
     it('makes a selection programmatically', async () => {
@@ -1159,25 +1177,23 @@ describe('auro-select keyboard behavior — Home key', () => {
     await elementUpdated(el);
     el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
     await elementUpdated(el);
-    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
-    await elementUpdated(el);
 
     const menu = el.querySelector('auro-menu');
     const lastOption = menu.querySelector('auro-menuoption[value="Duration"]');
-    await expect(el.optionActive).to.equal(lastOption);
+    await expect(el.optionActive === lastOption).to.be.true;
 
     // Press Home to go to first option
     el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Home' }));
     await elementUpdated(el);
 
     const firstOption = menu.querySelector('auro-menuoption[value="Stops"]');
-    await expect(el.optionActive).to.equal(firstOption);
+    await expect(el.optionActive === firstOption).to.be.true;
 
     // wrap to last option if Home is pressed again
     el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' }));
     await elementUpdated(el);
 
-    await expect(el.optionActive).to.equal(lastOption);
+    await expect(el.optionActive === lastOption).to.be.true;
   });
 
   it('skips disabled options and goes to first enabled option when Home is pressed', async () => {
@@ -1198,6 +1214,8 @@ describe('auro-select keyboard behavior — Home key', () => {
     await elementUpdated(el);
 
     // Navigate to the last option
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    await elementUpdated(el);
     el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
     await elementUpdated(el);
     el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -446,16 +446,11 @@ function runTest(mobileView) {
 
       el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
       await elementUpdated(el);
-
-      if (mobileView) {
-        el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
-      } else {
-        trigger.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
-      }
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
       await elementUpdated(el);
 
-      await waitUntil(() => dropdown.isPopoverVisible === false, 'Dropdown did not close after Enter key');
       await expect(el.value).to.equal('Oranges');
+      await expect(dropdown.isPopoverVisible).to.be.false;
     });
 
     // ─── §2.1.3  Tab selects active option and closes bib (P0) ──────────────
@@ -478,62 +473,25 @@ function runTest(mobileView) {
       await expect(el.value).to.equal('Oranges');
     });
 
-    // ─── §2.1.X  Shift+Tab moves active option to first non-disabled option (P0) ─
-    it('Shift+Tab moves active option to first option and keeps bib open', async () => {
-      const el = await shiftTabFixture();
+
+    // ─── §2.1.3  Tab selects active option and closes bib (P0) ──────────────
+    it('Shift+Tab selects the active option and closes the bib', async () => {
+      const el = await defaultFixture();
       const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
       const trigger = dropdown.querySelector('[slot="trigger"]');
-      const options = el.querySelectorAll('auro-menuoption');
 
       trigger.click();
       await elementUpdated(el);
       await expect(dropdown.isPopoverVisible).to.be.true;
 
-      // Navigate to the last option so active is NOT the first
       el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
       await elementUpdated(el);
-      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
-      await elementUpdated(el);
-      await expect(el.optionActive === options[2]).to.be.true;
 
-      // Shift+Tab should move to the first option without selecting or closing
       el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true }));
       await elementUpdated(el);
 
-      await expect(el.optionActive === options[0]).to.be.true;
-      await expect(dropdown.isPopoverVisible).to.be.true;
-      await expect(el.value).to.be.undefined;
-    });
-
-    it('Shift+Tab skips disabled first option when moving to first active option', async () => {
-      const el = await shiftTabDisabledFirstFixture();
-      const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
-      const trigger = dropdown.querySelector('[slot="trigger"]');
-      const options = el.querySelectorAll('auro-menuoption');
-
-      trigger.click();
-      await elementUpdated(el);
-      await expect(dropdown.isPopoverVisible).to.be.true;
-
-      // Navigate to last option
-      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
-      await elementUpdated(el);
-      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
-      await elementUpdated(el);
-
-      // Shift+Tab should land on options[1] (first non-disabled)
-      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true }));
-      await elementUpdated(el);
-
-      // options[0] is disabled so the first enabled option is options[1]
-      await expect(el.optionActive).to.equal(options[1]);
-      await expect(dropdown.isPopoverVisible).to.be.true;
-      await expect(el.value).to.be.undefined;
-
-      // Close bib so the disabled option is not visible during the post-test
-      // a11y check — disabled text color does not meet contrast ratios.
-      dropdown.hide();
-      await elementUpdated(el);
+      await expect(dropdown.isPopoverVisible).to.be.false;
+      await expect(el.value).to.equal('Oranges');
     });
 
     it('Shift+Tab with bib closed does nothing', async () => {

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -435,24 +435,6 @@ function runTest(mobileView) {
       });
     }
 
-    // ─── §2.1.2  Enter key selects active option and closes bib (P0) ────────
-    it('Enter key selects the active option and closes the bib', async () => {
-      const el = await defaultFixture();
-      const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
-      const trigger = dropdown.querySelector('[slot="trigger"]');
-
-      trigger.click();
-      await expect(dropdown.isPopoverVisible).to.be.true;
-
-      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
-      await elementUpdated(el);
-
-      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
-      await elementUpdated(el);
-
-      await expect(el.value).to.equal('Apples');
-      await expect(dropdown.isPopoverVisible).to.be.false;
-    });
 
     // ─── §2.1.3  Tab selects active option and closes bib (P0) ──────────────
     it('Tab selects the active option and closes the bib', async () => {
@@ -632,72 +614,6 @@ function runTest(mobileView) {
 
       await expect(trigger.ariaActiveDescendantElement).to.equal(firstOption);
     });
-
-    if (mobileView) {
-      // ─── §2.2.3  Option selection in fullscreen mode (P0) ───────────────────
-      it('selecting an option in fullscreen mode sets value and closes dialog', async () => {
-        const el = await defaultFixture();
-        const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
-        const trigger = dropdown.querySelector('[slot="trigger"]');
-
-        trigger.click();
-        await expect(dropdown.isPopoverVisible).to.be.true;
-
-        // Wait for fullscreen dialog to settle (double-rAF used by focus migration)
-        await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
-
-        el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
-        await elementUpdated(el);
-
-        el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
-        await elementUpdated(el);
-
-        await expect(el.value).to.equal('Apples');
-        await expect(dropdown.isPopoverVisible).to.be.false;
-      });
-
-      // ─── §2.2.4  Active-descendant state propagation to bib (P1) ─────────
-      it('dropdown mirrors hasActiveDescendant to bib so keyboard bridge distinguishes Enter-select from Enter-close', async () => {
-        const el = await defaultFixture();
-        const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
-        const trigger = dropdown.querySelector('[slot="trigger"]');
-        const bib = dropdown.bibContent;
-
-        trigger.click();
-        await expect(dropdown.isPopoverVisible).to.be.true;
-
-        // Wait for fullscreen dialog to settle (double-rAF used by focus migration)
-        await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
-
-        // No active descendant before navigation
-        expect(bib.hasActiveDescendant).to.not.be.true;
-
-        // Navigate to first option
-        el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
-        await elementUpdated(el);
-
-        // The dropdown should mirror active-descendant state to the bib
-        // so the keyboard bridge knows Enter should select, not close.
-        expect(bib.hasActiveDescendant).to.be.true;
-
-        // Simulate Enter originating from inside the fullscreen dialog while
-        // focus is on the close button, exercising the regression path.
-        const closeButton = el.bibtemplate.shadowRoot.querySelector('#closeButton');
-        expect(closeButton).to.exist;
-
-        closeButton.focus();
-        closeButton.dispatchEvent(new KeyboardEvent('keydown', {
-          key: 'Enter',
-          bubbles: true,
-          composed: true
-        }));
-        await elementUpdated(el);
-
-        // On first Enter, the focused option should be selected and the bib closed.
-        await expect(el.value).to.equal('Apples');
-        await expect(dropdown.isPopoverVisible).to.be.false;
-      });
-    }
 
     it('Navigates the menu with arrow keys', async () => {
       const el = await defaultFixture();
@@ -1215,5 +1131,246 @@ describe('selectKeyboardStrategy — Tab multiselect', () => {
 
     expect(selectionCalled).to.be.false;
     expect(hideCalled).to.be.true;
+  });
+});
+
+// ─── Keyboard Behavior Tests ───────────────────────────────────────────────────
+
+describe('auro-select keyboard behavior — Home key', () => {
+  it('moves to the first enabled option when Home is pressed while expanded', async () => {
+    const el = await fixture(html`
+      <auro-select>
+        <span slot="bib.fullscreen.headline">Bib Headline</span>
+        <span slot="label">Name</span>
+        <auro-menu>
+          <auro-menuoption value="Stops">Stops</auro-menuoption>
+          <auro-menuoption value="Price">Price</auro-menuoption>
+          <auro-menuoption value="Duration">Duration</auro-menuoption>
+        </auro-menu>
+      </auro-select>
+    `);
+
+    await elementUpdated(el);
+    el.showBib();
+    await elementUpdated(el);
+
+    // Navigate to the last option
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    await elementUpdated(el);
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    await elementUpdated(el);
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    await elementUpdated(el);
+
+    const menu = el.querySelector('auro-menu');
+    const lastOption = menu.querySelector('auro-menuoption[value="Duration"]');
+    await expect(el.optionActive).to.equal(lastOption);
+
+    // Press Home to go to first option
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Home' }));
+    await elementUpdated(el);
+
+    const firstOption = menu.querySelector('auro-menuoption[value="Stops"]');
+    await expect(el.optionActive).to.equal(firstOption);
+
+    // wrap to last option if Home is pressed again
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' }));
+    await elementUpdated(el);
+
+    await expect(el.optionActive).to.equal(lastOption);
+  });
+
+  it('skips disabled options and goes to first enabled option when Home is pressed', async () => {
+    const el = await fixture(html`
+      <auro-select>
+        <span slot="bib.fullscreen.headline">Bib Headline</span>
+        <span slot="label">Name</span>
+        <auro-menu>
+          <auro-menuoption value="Stops" disabled>Stops</auro-menuoption>
+          <auro-menuoption value="Price">Price</auro-menuoption>
+          <auro-menuoption value="Duration">Duration</auro-menuoption>
+        </auro-menu>
+      </auro-select>
+    `);
+
+    await elementUpdated(el);
+    el.showBib();
+    await elementUpdated(el);
+
+    // Navigate to the last option
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    await elementUpdated(el);
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    await elementUpdated(el);
+
+    await expect(el.optionActive.value).to.equal('Duration');
+
+    // Press Home, should skip the disabled first option and go to "Price"
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Home' }));
+    await elementUpdated(el);
+
+    const menu = el.querySelector('auro-menu');
+    const firstEnabledOption = menu.querySelector('auro-menuoption[value="Price"]');
+    await expect(el.optionActive).to.equal(firstEnabledOption);
+  });
+
+  it('does not change active option when all options are disabled and Home is pressed', async () => {
+    const el = await fixture(html`
+      <auro-select>
+        <span slot="bib.fullscreen.headline">Bib Headline</span>
+        <span slot="label">Name</span>
+        <auro-menu>
+          <auro-menuoption value="Stops" disabled>Stops</auro-menuoption>
+          <auro-menuoption value="Price" disabled>Price</auro-menuoption>
+          <auro-menuoption value="Duration" disabled>Duration</auro-menuoption>
+        </auro-menu>
+      </auro-select>
+    `);
+
+    await elementUpdated(el);
+    el.showBib();
+    await elementUpdated(el);
+
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Home' }));
+    await elementUpdated(el);
+
+    await expect(el.optionActive).to.equal(undefined);
+  });
+
+  it('does nothing when Home is pressed while collapsed', async () => {
+    const el = await fixture(html`
+      <auro-select>
+        <span slot="bib.fullscreen.headline">Bib Headline</span>
+        <span slot="label">Name</span>
+        <auro-menu>
+          <auro-menuoption value="Stops">Stops</auro-menuoption>
+          <auro-menuoption value="Price">Price</auro-menuoption>
+        </auro-menu>
+      </auro-select>
+    `);
+
+    await elementUpdated(el);
+
+    const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+    await expect(dropdown.isPopoverVisible).to.be.false;
+
+    // Press Home while collapsed
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Home' }));
+    await elementUpdated(el);
+
+    // Dropdown should still be closed
+    await expect(dropdown.isPopoverVisible).to.be.false;
+  });
+});
+
+describe('auro-select keyboard behavior — End key', () => {
+  it('moves to the last enabled option when End is pressed while expanded', async () => {
+    const el = await fixture(html`
+      <auro-select>
+        <span slot="bib.fullscreen.headline">Bib Headline</span>
+        <span slot="label">Name</span>
+        <auro-menu>
+          <auro-menuoption value="Stops">Stops</auro-menuoption>
+          <auro-menuoption value="Price">Price</auro-menuoption>
+          <auro-menuoption value="Duration">Duration</auro-menuoption>
+        </auro-menu>
+      </auro-select>
+    `);
+
+    await elementUpdated(el);
+    el.showBib();
+    await elementUpdated(el);
+
+    // Press End to go to last option
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'End' }));
+    await elementUpdated(el);
+
+    const menu = el.querySelector('auro-menu');
+    const lastOption = menu.querySelector('auro-menuoption[value="Duration"]');
+    await expect(el.optionActive).to.equal(lastOption);
+  });
+
+  it('skips disabled options and goes to last enabled option when End is pressed', async () => {
+    const el = await fixture(html`
+      <auro-select>
+        <span slot="bib.fullscreen.headline">Bib Headline</span>
+        <span slot="label">Name</span>
+        <auro-menu>
+          <auro-menuoption value="Stops">Stops</auro-menuoption>
+          <auro-menuoption value="Price">Price</auro-menuoption>
+          <auro-menuoption value="Duration" disabled>Duration</auro-menuoption>
+        </auro-menu>
+      </auro-select>
+    `);
+
+    await elementUpdated(el);
+    el.showBib();
+    await elementUpdated(el);
+
+    // Press End, should skip the disabled last option and go to "Price"
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'End' }));
+    await elementUpdated(el);
+
+    const menu = el.querySelector('auro-menu');
+    const lastEnabledOption = menu.querySelector('auro-menuoption[value="Price"]');
+    await expect(el.optionActive).to.equal(lastEnabledOption);
+
+
+    // wrap to first option if Home is pressed again
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    await elementUpdated(el);
+
+    const firstOption = menu.querySelector('auro-menuoption[value="Stops"]');
+    await expect(el.optionActive).to.equal(firstOption);
+
+
+  });
+
+  it('does not change active option when all options are disabled and End is pressed', async () => {
+    const el = await fixture(html`
+      <auro-select>
+        <span slot="bib.fullscreen.headline">Bib Headline</span>
+        <span slot="label">Name</span>
+        <auro-menu>
+          <auro-menuoption value="Stops" disabled>Stops</auro-menuoption>
+          <auro-menuoption value="Price" disabled>Price</auro-menuoption>
+          <auro-menuoption value="Duration" disabled>Duration</auro-menuoption>
+        </auro-menu>
+      </auro-select>
+    `);
+
+    await elementUpdated(el);
+    el.showBib();
+    await elementUpdated(el);
+
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'End' }));
+    await elementUpdated(el);
+
+    await expect(el.optionActive).to.equal(undefined);
+  });
+
+  it('does nothing when End is pressed while collapsed', async () => {
+    const el = await fixture(html`
+      <auro-select>
+        <span slot="bib.fullscreen.headline">Bib Headline</span>
+        <span slot="label">Name</span>
+        <auro-menu>
+          <auro-menuoption value="Stops">Stops</auro-menuoption>
+          <auro-menuoption value="Price">Price</auro-menuoption>
+        </auro-menu>
+      </auro-select>
+    `);
+
+    await elementUpdated(el);
+
+    const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+    await expect(dropdown.isPopoverVisible).to.be.false;
+
+    // Press End while collapsed
+    el.dispatchEvent(new KeyboardEvent('keydown', { key: 'End' }));
+    await elementUpdated(el);
+
+    // Dropdown should still be closed
+    await expect(dropdown.isPopoverVisible).to.be.false;
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
       "devDependencies": {
         "@aurodesignsystem/auro-accordion": "^6.1.1",
         "@aurodesignsystem/auro-button": "^12.3.2",
-        "@aurodesignsystem/auro-library": "^5.11.3",
+        "@aurodesignsystem/auro-library": "^5.12.0",
         "@aurodesignsystem/auro-loader": "^6.2.0",
         "@aurodesignsystem/build-tools": "*",
         "@aurodesignsystem/config": "*",
@@ -1113,9 +1113,9 @@
       "link": true
     },
     "node_modules/@aurodesignsystem/auro-library": {
-      "version": "5.11.3",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-library/-/auro-library-5.11.3.tgz",
-      "integrity": "sha512-SxCUTj9Zzn6mP5LOyBg/2ENELe+lkTwMWDzkx9HDeFEkrzChH1nGZ967i7OuE113PO+01K/xMBzFxstih0FQsg==",
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-library/-/auro-library-5.12.0.tgz",
+      "integrity": "sha512-Fo2Qc28yY9W+vscrxikLuEBiGPpSdviWQW/dfqQmXDtb+sagIEhbMh3SSGnXKOmP6aOEJj9gnRNJP9kMjbJKtA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -76,13 +76,14 @@
     "lit": "^3.3.1"
   },
   "optionalDependencies": {
-    "@rollup/rollup-linux-x64-gnu": "*",
-    "@rolldown/binding-linux-x64-gnu": "*"
+    "@rolldown/binding-linux-x64-gnu": "*",
+    "@rollup/rollup-linux-x64-gnu": "*"
   },
   "devDependencies": {
     "@aurodesignsystem/auro-accordion": "^6.1.1",
     "@aurodesignsystem/auro-button": "^12.3.2",
-    "@aurodesignsystem/auro-library": "^5.11.3",
+    "@aurodesignsystem/auro-library": "^5.12.0",
+    "@aurodesignsystem/auro-loader": "^6.2.0",
     "@aurodesignsystem/build-tools": "*",
     "@aurodesignsystem/config": "*",
     "@aurodesignsystem/design-tokens": "^8.15.1",
@@ -92,7 +93,6 @@
     "@aurodesignsystem/utils": "*",
     "@aurodesignsystem/version": "*",
     "@aurodesignsystem/webcorestylesheets": "^10.1.4",
-    "@aurodesignsystem/auro-loader": "^6.2.0",
     "@chromatic-com/storybook": "^5.0.0",
     "@commitlint/cli": "^19.8.1",
     "@commitlint/config-conventional": "^19.8.1",


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Review Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Improve keyboard and focus handling for the select dropdown component.

Bug Fixes:
- Prevent Enter key from committing a selection when the select is already expanded by the positioning library.
- Adjust focus restoration on dropdown close so Tab navigation behaves correctly depending on fullscreen state.

Enhancements:
- Add Home and End keyboard support to move the active option to the first or last item in the select menu.