### PR TITLE
fix(menu|select): prevent deselecting only option in single-select

### DIFF
--- a/components/menu/src/auro-menu.context.js
+++ b/components/menu/src/auro-menu.context.js
@@ -318,7 +318,12 @@ export class MenuService {
     const isOnlySelectedOption = this.selectedOptions.length === 1 && optionsToDeselect.includes(this.selectedOptions[0]);
 
     // Prevent deselecting the only selected option if not allowed
-    if (shouldPreventDeselect && isOnlySelectedOption) return;
+    if (shouldPreventDeselect && isOnlySelectedOption) {
+      optionsToDeselect.forEach(option => {
+        option.selected = true;
+      })
+      return;
+    }
 
     const optionsSet = new Set(optionsToDeselect);
     this.selectedOptions = (this.selectedOptions || [])

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -777,18 +777,18 @@ function runTest(mobileView) {
     describe('Mouse Behavior', () => {
       describe('Click', () => {
         describe('Trigger', () => {
-          // it('should toggle the bib on click', async () => {
-          //   const el = await defaultFixture();
+          it('should toggle the bib on click', async () => {
+            const el = await defaultFixture();
 
-          //   const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
-          //   const trigger = dropdown.querySelector('[slot="trigger"]');
+            const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+            const trigger = dropdown.querySelector('[slot="trigger"]');
 
-          //   trigger.click();
-          //   await expect(dropdown.isPopoverVisible).to.be.true;
+            trigger.click();
+            await expect(dropdown.isPopoverVisible).to.be.true;
 
-          //   trigger.click();
-          //   await expect(dropdown.isPopoverVisible).to.be.false;
-          // });
+            trigger.click();
+            await expect(dropdown.isPopoverVisible).to.be.false;
+          });
 
           // // BUG: The select uses popover='manual' which does not support light dismiss,
           // // and noHideOnThisFocusLoss is set to true, so clicking outside does not close the bib.
@@ -835,40 +835,40 @@ function runTest(mobileView) {
               await expect(dropdown.isPopoverVisible).to.be.false;
             });
 
-            // it('should not deselect and should close the bib when an already-selected menuoption is clicked', async () => {
-            //   const el = await presetValueFixture();
+            it('should not deselect and should close the bib when an already-selected menuoption is clicked', async () => {
+              const el = await presetValueFixture();
 
-            //   await elementUpdated(el);
-            //   await new Promise((resolve) => setTimeout(resolve, 0));
-            //   await elementUpdated(el);
+              await elementUpdated(el);
+              await new Promise((resolve) => setTimeout(resolve, 0));
+              await elementUpdated(el);
 
-            //   const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
-            //   const trigger = dropdown.querySelector('[slot="trigger"]');
+              const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+              const trigger = dropdown.querySelector('[slot="trigger"]');
 
-            //   trigger.click();
-            //   await elementUpdated(el);
-            //   await expect(dropdown.isPopoverVisible).to.be.true;
+              trigger.click();
+              await elementUpdated(el);
+              await expect(dropdown.isPopoverVisible).to.be.true;
 
-            //   const menu = el.querySelector('auro-menu');
-            //   const selectedOption = menu.querySelector('auro-menuoption[value="price"]');
-            //   await expect(selectedOption.selected).to.be.true;
+              const menu = el.querySelector('auro-menu');
+              const selectedOption = menu.querySelector('auro-menuoption[value="price"]');
+              await expect(selectedOption.selected).to.be.true;
 
-            //   const valueBefore = el.value;
+              const valueBefore = el.value;
 
-            //   // Wait for menu option internal state to settle
-            //   await new Promise((resolve) => setTimeout(resolve, 0));
+              // Wait for menu option internal state to settle
+              await new Promise((resolve) => setTimeout(resolve, 0));
 
-            //   selectedOption.click();
-            //   await elementUpdated(selectedOption);
-            //   await elementUpdated(menu);
-            //   await new Promise((resolve) => setTimeout(resolve, 0));
-            //   await elementUpdated(el);
+              selectedOption.click();
+              await elementUpdated(selectedOption);
+              await elementUpdated(menu);
+              await new Promise((resolve) => setTimeout(resolve, 0));
+              await elementUpdated(el);
 
-            //   // In single-select mode, clicking an already-selected option should NOT deselect it
-            //   await expect(selectedOption.selected).to.be.true;
-            //   await expect(el.value).to.equal(valueBefore);
-            //   await expect(dropdown.isPopoverVisible).to.be.false;
-            // });
+              // In single-select mode, clicking an already-selected option should NOT deselect it
+              await expect(selectedOption.selected).to.be.true;
+              await expect(el.value).to.equal(valueBefore);
+              await expect(dropdown.isPopoverVisible).to.be.false;
+            });
 
             it('should not select or close the bib when a disabled menuoption is clicked', async () => {
               const el = await fixture(html`


### PR DESCRIPTION
# Alaska Airlines Pull Request

## Review Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Ensure single-select menus do not allow deselecting the only selected option when deselection is disabled, and validate this behavior with restored interaction tests.

Enhancements:
- Adjust menu selection logic so single-select menus preserve the selected option when deselection is not allowed, keeping the option selected even when clicked again.

Tests:
- Re-enable mouse interaction tests for opening/closing the select dropdown and for preventing deselection when clicking an already-selected option in single-select mode.