### PR TITLE
fix(menu|select|combobox): emit deselectPrevented and close bib

### DIFF
--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -1012,6 +1012,10 @@ export class AuroCombobox extends AuroElement {
       this.menu.setAttribute('nocheckmark', '');
     }
 
+    this.menu.addEventListener("auroMenu-deselectPrevented", () => {
+      this.hideBib();
+    });
+
     // Handle menu option selection like select does
     this.menu.addEventListener('auroMenu-selectedOption', (event) => {
       // Update the optionSelected from the event details, not manually

--- a/components/combobox/test/auro-combobox.test.js
+++ b/components/combobox/test/auro-combobox.test.js
@@ -1301,7 +1301,7 @@ function runFullTest(mobileView) {
             await expect(el.dropdown.isPopoverVisible).to.be.true;
           });
 
-          it('should close the bib when an already-selected menuoption is clicked', async () => {
+          it('should not deselect and should close the bib when an already-selected menuoption is clicked', async () => {
             const el = await presetValueFixture(mobileView);
 
             el.focus();

--- a/components/menu/docs/api.md
+++ b/components/menu/docs/api.md
@@ -37,6 +37,7 @@ The `auro-menu` element provides users a way to select from a list of options.
 |-------------------------------|--------------------------------------------------|--------------------------------------------------|
 | `auroMenu-activatedOption`    | `CustomEvent<Element>`                           | Notifies that a menuoption has been made `active`. |
 | `auroMenu-customEventFired`   | `CustomEvent<any>`                               | Notifies that a custom event has been fired.     |
+| `auroMenu-deselectPrevented`  | `CustomEvent<{ values: HTMLElement[] }>`         | Notifies that deselection was prevented and includes the affected options in `detail.values`. |
 | `auroMenu-loadingChange`      | `CustomEvent<{ loading: boolean; hasLoadingPlaceholder: boolean; }>` | Notifies when the loading attribute is changed.  |
 | `auroMenu-optionsChange`      | `CustomEvent<{ options: any; }>`                 |                                                  |
 | `auroMenu-selectValueFailure` | `CustomEvent<any>`                               | Notifies that an attempt to select a menuoption by matching a value has failed. |

--- a/components/menu/src/auro-menu.context.js
+++ b/components/menu/src/auro-menu.context.js
@@ -321,7 +321,10 @@ export class MenuService {
     if (shouldPreventDeselect && isOnlySelectedOption) {
       optionsToDeselect.forEach(option => {
         option.selected = true;
-      })
+      });
+      this.dispatchChangeEvent('auroMenu-deselectPrevented', {
+        values: optionsToDeselect
+      });
       return;
     }
 

--- a/components/menu/src/auro-menu.js
+++ b/components/menu/src/auro-menu.js
@@ -29,6 +29,7 @@ import { ContextProvider } from "@lit/context";
  * @event {CustomEvent<any>} auroMenu-customEventFired - Notifies that a custom event has been fired.
  * @event {CustomEvent<{ loading: boolean; hasLoadingPlaceholder: boolean; }>} auroMenu-loadingChange - Notifies when the loading attribute is changed.
  * @event {CustomEvent<any>} auroMenu-selectValueFailure - Notifies that an attempt to select a menuoption by matching a value has failed.
+ * @event {CustomEvent<{ values: HTMLElement[] }>} auroMenu-deselectPrevented - Notifies that deselection was prevented and includes the affected options in `detail.values`.
  * @event {CustomEvent<any>} auroMenu-selectValueReset - Notifies that the component value has been reset.
  * @event {CustomEvent<any>} auroMenu-selectedOption - Notifies that a new menuoption selection has been made.
  * @slot loadingText - Text to show while loading attribute is set

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -800,6 +800,10 @@ export class AuroSelect extends AuroElement {
     this.updateOptionPositions();
     this.menu.addEventListener("auroMenu-loadingChange", (event) => this.handleMenuLoadingChange(event));
 
+    this.menu.addEventListener("auroMenu-deselectPrevented", () => {
+      this.hideBib();
+    });
+
     this.menu.addEventListener('auroMenu-activatedOption', (evt) => {
       this.optionActive = evt.detail;
 

--- a/components/select/src/auro-select.js
+++ b/components/select/src/auro-select.js
@@ -568,14 +568,16 @@ export class AuroSelect extends AuroElement {
 
         // If there's a selected option, highlight it (per W3C APG combobox-select-only pattern)
         // No selection → first enabled option gets highlighted
-        if (this.optionSelected && !Array.isArray(this.optionSelected)) {
-          this.menu.updateActiveOption(this.optionSelected);
-        } else if (this.multiSelect && Array.isArray(this.optionSelected) && this.optionSelected.length > 0) {
-          this.menu.updateActiveOption(this.optionSelected[0]);
-        } else if (!this.menu.optionActive) {
-          // If no activeOption has yet to be set, then make the first enabled option active by default
-          const firstActive = this.menu.menuService.menuOptions.find((option) => !option.disabled);
-          this.menu.updateActiveOption(firstActive);
+        if (!this.menu.optionActive) {
+          if (this.optionSelected && !Array.isArray(this.optionSelected)) {
+            this.menu.updateActiveOption(this.optionSelected);
+          } else if (this.multiSelect && Array.isArray(this.optionSelected) && this.optionSelected.length > 0) {
+            this.menu.updateActiveOption(this.optionSelected[0]);
+          } else {
+            // If no activeOption has yet to be set, then make the first enabled option active by default
+            const firstActive = this.menu.menuService.menuOptions.find((option) => !option.disabled);
+            this.menu.updateActiveOption(firstActive);
+          }
         }
 
         // Scroll the selected option into view when dropdown opens

--- a/components/select/test/auro-select.test.js
+++ b/components/select/test/auro-select.test.js
@@ -1280,6 +1280,43 @@ function runTest(mobileView) {
           await expect(dropdown.isPopoverVisible).to.be.false;
         });
 
+        it('should not deselect and should close the bib when Enter is pressed on an already-selected menuoption', async () => {
+          const el = await presetValueFixture();
+
+          await elementUpdated(el);
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          await elementUpdated(el);
+
+          const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');
+          const trigger = dropdown.querySelector('[slot="trigger"]');
+
+          trigger.click();
+          await elementUpdated(el);
+          await expect(dropdown.isPopoverVisible).to.be.true;
+
+          const menu = el.querySelector('auro-menu');
+          const selectedOption = menu.querySelector('auro-menuoption[value="price"]');
+          await expect(selectedOption.selected).to.be.true;
+
+          const valueBefore = el.value;
+          let deselectPreventedEvent = null;
+
+          menu.addEventListener('auroMenu-deselectPrevented', (event) => {
+            deselectPreventedEvent = event;
+          }, { once: true });
+
+          el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+          await elementUpdated(menu);
+          await elementUpdated(el);
+          await waitUntil(() => !!deselectPreventedEvent);
+
+          await expect(deselectPreventedEvent).to.exist;
+          await expect(deselectPreventedEvent.detail.values[0]).to.equal(selectedOption);
+          await expect(selectedOption.selected).to.be.true;
+          await expect(el.value).to.equal(valueBefore);
+          await expect(dropdown.isPopoverVisible).to.be.false;
+        });
+
         it('should keep the dropdown open in multiselect mode', async () => {
           const el = await multiSelectFixture();
           const dropdown = el.shadowRoot.querySelector('[auro-dropdown]');


### PR DESCRIPTION
# Alaska Airlines Pull Request

fire `auroMenu-deselectPrevented` when trying to deselect on an already selected option of a single select

## Review Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Handle failed deselection attempts in single-select menus and ensure the select dropdown closes appropriately.

Bug Fixes:
- Prevent deselection of the only selected option in single-select menus while still closing the dropdown when Enter is pressed on that option.

Tests:
- Add regression test verifying that pressing Enter on an already-selected option does not change selection, emits a failure event, and closes the dropdown.