### PR TITLE
changes of 5.8.1 -> 5.8.2

### DIFF
--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -663,7 +663,9 @@ export class AuroCombobox extends AuroElement {
    * @returns {void}
    */
   showBib() {
-    if (!this.input.value) {
+    // for fullscreen bib, with `noFilter` showBib() gets called again as availableOptions gets updated
+    // to prevent closing bib in that case, adding guard not to hide bib for empty input on fullscreen bib
+    if (!this.input.value && !this.dropdown.isBibFullscreen) {
       this.dropdown.hide();
       return;
     }

--- a/components/combobox/src/auro-combobox.js
+++ b/components/combobox/src/auro-combobox.js
@@ -920,8 +920,33 @@ export class AuroCombobox extends AuroElement {
    * @returns {void}
    */
   handleInputValueChange(event) {
+    // When the event comes from the fullscreen bib input, sync the value to
+    // the trigger input. Setting trigger.value triggers Lit's updated()
+    // (async, microtask) which fires notifyValueChanged() → another 'input'
+    // event from the trigger. The _syncingBibValue guard persists across the
+    // async boundary and prevents that re-entrant event from running the
+    // non-fullscreen path (which would call clear() → hideBib()).
+    // When the event comes from the fullscreen bib input, sync the value to
+    // the trigger and run filtering, but suppress the re-entrant input event
+    // that the trigger fires (via Lit updated() → notifyValueChanged()) so
+    // the non-fullscreen hide/clear logic doesn't close the dialog.
     if (event.target === this.inputInBib) {
+      this._syncingBibValue = true;
       this.input.value = this.inputInBib.value;
+      this.input.updateComplete.then(() => {
+        this._syncingBibValue = false;
+      });
+
+      // Run filtering inline — the re-entrant event won't reach this code.
+      this.menu.matchWord = this.inputInBib.value;
+      this.optionActive = null;
+      this.handleMenuOptions();
+      this.dispatchEvent(new CustomEvent('inputValue', { detail: { value: this.inputValue } }));
+      return;
+    }
+
+    // Ignore re-entrant input events caused by the bib→trigger sync above.
+    if (this._syncingBibValue) {
       return;
     }
 

--- a/components/input/src/base-input.js
+++ b/components/input/src/base-input.js
@@ -828,11 +828,10 @@ export default class BaseInput extends AuroElement {
    */
   handleClickClear() {
     this.inputElement.value = "";
-    this.value = "";
     this.labelElement.classList.remove('inputElement-label--sticky');
+    this.validation.reset(this);
     this.notifyValueChanged();
     this.focus();
-    this.validation.validate(this);
   }
 
   /**

--- a/components/input/test/auro-input.test.js
+++ b/components/input/test/auro-input.test.js
@@ -104,7 +104,7 @@ describe('auro-input', () => {
     const clearButton = el.shadowRoot.querySelector('.clearBtn');
     clearButton.click();
     await elementUpdated();
-    expect(el.value).to.equal('');
+    expect(el.value).to.undefined;
   });
 
   it('flips hide-password bit', async () => {


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Review Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-formkit/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Ensure combobox fullscreen bib remains open when clearing or syncing input values and adjust base input clear behavior and tests accordingly.

Bug Fixes:
- Prevent fullscreen bib from closing when combobox input is cleared while in noFilter fullscreen mode.
- Avoid re-entrant input handling when syncing values between fullscreen bib input and combobox trigger input.
- Fix input clear button behavior so it clears the DOM value, resets validation, and relies on value change notification instead of directly mutating the component value.
- Update input component tests to reflect the new clear behavior where the public value becomes undefined after clearing.